### PR TITLE
Frontend sync, search, DB loading/reading performance fixes

### DIFF
--- a/client/src/frontend-utils/time.ts
+++ b/client/src/frontend-utils/time.ts
@@ -37,7 +37,7 @@ export function convertTimeAndDateToTimestamp(dateString: string, timeString: st
   //console.log("Constructed dateTime object:", dateTime);
   // Parse date object into a qcalendar timestamp
   const timeStamp = parseDate(dateTime);
- // console.log("Converted Timestamp:", timeStamp);
+  //console.log("Converted Timestamp:", timeStamp);
   // Return object that has all timestamp fields plus original date for UI rendering
   return {
   ...timeStamp,

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -24,6 +24,7 @@ export type UINote = Note & {
   temporaryTitle: string;
   temporaryText: string;
   temporaryFolderID: bigint | null; 
+  temporaryLastModified: string;
   titleMessageError?: string;
   folderMessageError?: string;
   isSaved: boolean;
@@ -40,6 +41,7 @@ export type UIReminder = Reminder & {
   temporaryNotificationTime: number | null;
   temporaryEventStartTime: string | null;
   temporaryEventEndTime: string | null;
+  temporaryLastModified: string;
   titleMessageError?: string;
   folderMessageError?: string;
   timeMessageError?: string;


### PR DESCRIPTION
- User can select an entry on the calendar to route to it
- Event date (for reminders) and last modified time (in local timezone) now display on reminder/note cards in list
- Reminders for the calendar are now only loaded in range of the viewable month/year
- Fixed issue with fetching reminder/note rows twice
- Fixed issue with other note/reminder cards being expanded when routing to specific entry
- Frontend cloud sync status message and toggle button in settings areconnected to sync function
- User can search reminder/notes in list by title
- File explorer tree was fixed to be built from inside root folder