### PR TITLE
Frontend Recurring & Generated Reminders

### DIFF
--- a/client/src/css/app.scss
+++ b/client/src/css/app.scss
@@ -3,7 +3,7 @@
 /* 
  * Authors: Rachel Patella, Maria Pasaylo
  * Created: 2025-04-13
- * Updated: 2025-11-10
+ * Updated: 2025-11-21
  *
  * This file is the CSS global stylesheet for the application
  *
@@ -242,4 +242,9 @@ overflow-wrap: break-word;
 .flight-half {
   background-color: #f2f2f2;
   margin-bottom: 5px;
+}
+
+// Hide year/month navigation in the day picker so only days 1-31 are shown
+.monthly-day-picker .q-date__navigation {
+  display: none !important;
 }

--- a/client/src/frontend-utils/events.ts
+++ b/client/src/frontend-utils/events.ts
@@ -1,7 +1,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-23
- * Updated: 2025-11-12
+ * Updated: 2025-11-24
  *
  * This file contains functions to build calendar events from reminders and retrieve event type details
  *
@@ -106,7 +106,6 @@ export function buildCalendarEvents(reminders: UIReminder[], eventTypes: EventTy
   return events;
 }
 
-
 // Map dates to array of events - key is date string, value is array of events on that date
 // script source code similar to slot - day month example
 // https://qcalendar.netlify.app/developing/qcalendar-month
@@ -144,4 +143,10 @@ export function getEventEndLabel(eventType: number) {
   }
   // General
   return 'Event End Time'; 
+}
+
+// Remove padding null characters from extension strings received by database for UI display
+export function stripNulls(fieldString?: string | null): string {
+  // Globally replace all null characters with empty string and trim whitespace
+  return (fieldString ?? '').replace(/\0/g, '').trim();
 }

--- a/client/src/frontend-utils/events.ts
+++ b/client/src/frontend-utils/events.ts
@@ -70,6 +70,10 @@ export function buildCalendarEvents(reminders: UIReminder[], eventTypes: EventTy
 
   // Iterate through viewable calendar month reminders
   for (const reminder of reminders) {
+    // Do not push calendar event for a recurring reminder
+      if (reminder.isRecurring) {
+        continue;
+      }
        // Build a single-day calendar event for each saved reminder in the viewable month
        if (reminder.isSaved) {
         events.push({

--- a/client/src/frontend-utils/events.ts
+++ b/client/src/frontend-utils/events.ts
@@ -1,7 +1,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-23
- * Updated: 2025-11-24
+ * Updated: 2025-11-25
  *
  * This file contains functions to build calendar events from reminders and retrieve event type details
  *
@@ -76,33 +76,44 @@ export function buildCalendarEvents(reminders: UIReminder[], eventTypes: EventTy
       }
        // Build a single-day calendar event for each saved reminder in the viewable month
        if (reminder.isSaved) {
+       // Get start and end date for the reminder
+       const startDateStr = reminder.date;
+       const endDateStr = reminder.temporaryEventEndDateEnabled ? reminder.temporaryEventEndDay : reminder.date;
+
+      // Create date objects from start and end date to safely iterate through dates
+      const [startYearString, startMonthString, startDayString] = startDateStr.split('-');
+      const [endYearString, endMonthString, endDayString] = endDateStr.split('-');
+      const startYear = Number(startYearString);
+      const startMonth = Number(startMonthString);
+      const startDay = Number(startDayString);
+      const endYear = Number(endYearString);
+      const endMonth = Number(endMonthString);
+      const endDay = Number(endDayString);
+
+      const startDate = new Date(startYear, startMonth - 1, startDay);
+      const endDate = new Date(endYear, endMonth - 1, endDay);
+
+      // Create a calendar event on every date in the range from the start to the end date
+      while (startDate <= endDate) {
+        // Local variable for current date string in YYYY-MM-DD format
+        const currentDate = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2,'0')}-${String(startDate.getDate()).padStart(2,'0')}`;
         events.push({
           id: reminder.itemID,
           title: reminder.title,
-          date: reminder.date,
+          date: currentDate,
           color: getEventTypeColor(eventTypes, reminder.eventType),
           icon: getEventTypeIcons(eventTypes, reminder.eventType),
-          isStart: true,
-          // End day is true if single-day event (as its the start and end)
-          isEnd: reminder.temporaryEventEndDay === reminder.date
+          // Start date is true if current date matches start date
+          isStart: currentDate === startDateStr,
+          // End date is true if current date matches end date
+          // Both isStart and isEnd will be true for a same-day reminder (since startDate = endDate) for tooltip viewing
+          isEnd: currentDate === endDateStr
         });
-
-        // If reminder is a multi-event, create a marker on the end day (when viewed on calendar month)
-        if (reminder.temporaryEventEndDateEnabled) {
-          if (reminder.temporaryEventEndDay != reminder.date)  {
-            events.push({
-            id: reminder.itemID,
-            title: reminder.title,
-            date: reminder.temporaryEventEndDay,
-            color: getEventTypeColor(eventTypes, reminder.eventType),
-            icon: 'stop_circle',
-            isEnd: true
-            });
-          } 
-        }
+        // Increment date by one day for next iteration
+        startDate.setDate(startDate.getDate() + 1);
       }
     }
-
+  }
   return events;
 }
 

--- a/client/src/frontend-utils/time.ts
+++ b/client/src/frontend-utils/time.ts
@@ -1,7 +1,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-23
- * Updated: 2025-11-12
+ * Updated: 2025-11-24
  *
  * This file contains helper functions to handle time and date conversions on the client
  *
@@ -148,6 +148,66 @@ export function eventDatetoLocaleString(dateString: string): string {
   // String in MM/DD/YYYY format based on date
   const dateFormattedString = String(dateFormatted.getMonth() + 1).padStart(2, '0') + '/' + String(dateFormatted.getDate()).padStart(2, '0') + '/' + String(dateFormatted.getFullYear());
   return dateFormattedString;
+}
+
+// Helper function to determine days user can pick for event end day (from start day to one year later)
+// Hard limits reminders to +1 year from start date for event duration
+export function endDateRange(startDate: string, fallbackDate: string): { min: string; max: string } {
+  // Normalize inputted date string to yyyy-mm-dd format
+  let dateString = normalizeDatePickerToCalendar(startDate ?? '') || '';
+  // If provided startDate is empty/invalid, fallback to currently selected calendar date
+  if (!dateString) {
+    dateString = normalizeDatePickerToCalendar(String(fallbackDate ?? '')) || '';
+  }
+
+  if (dateString) {
+    const [yearString, monthString, dayString] = dateString.split('-');
+    const year = Number(yearString);
+    const month = Number(monthString);
+    const day = Number(dayString);
+    // Create a new start date object from inputted start date with 0 hours, minutes, seconds to compare full day
+    const sDate = new Date(year, month - 1, day);
+    sDate.setHours(0, 0, 0, 0);
+
+    const endDate = new Date(sDate);
+    // Takes the start date (0 time) and adds 365 days to it for max end date
+    endDate.setDate(endDate.getDate() + 365);
+
+    const startString = `${sDate.getFullYear()}-${String(sDate.getMonth() + 1).padStart(2, '0')}-${String(sDate.getDate()).padStart(2, '0')}`;
+    const endString = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}`;
+
+    // Return the min and max date strings in yyyy-mm-dd format for date picker
+    return { min: startString, max: endString };
+  }
+
+  // If input is invalid or empty, return empty strings to satisfy the declared return type
+  return { min: '', max: '' };
+}
+
+// Helper function to determine days user can pick for series end day (from start day to 100 years later)
+export function endDateRangeRecurring(startDate: string, fallbackDate: string) {
+  let dateString = normalizeDatePickerToCalendar(startDate ?? '') || '';
+  // If provided startDate is empty/invalid, fallback to currently selected calendar date
+  if (!dateString) {
+    dateString = normalizeDatePickerToCalendar(String(fallbackDate ?? '')) || '';
+  }
+
+  if (dateString) {
+    const [yearString, monthString, dayString] = dateString.split('-');
+    const year = Number(yearString);
+    const month = Number(monthString);
+    const day = Number(dayString);
+    // Create a new start date object from inputted start date with 0 hours, minutes, seconds to compare full day
+    const sDate = new Date(year, month - 1, day);
+    sDate.setHours(0, 0, 0, 0);
+
+    const endDate = new Date(sDate);
+    // Takes the start date (0 time) and add 100 years for end date
+    endDate.setFullYear(endDate.getFullYear() + 100);
+    const endString = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}`;
+
+    return endString;
+  }
 }
 
 

--- a/client/src/frontend-utils/tree.ts
+++ b/client/src/frontend-utils/tree.ts
@@ -1,7 +1,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-23
- * Updated: 2025-10-29
+ * Updated: 2025-11-24
  *
  * This file contains functions to create the file explorer tree structure and breadcrumb trail path
  *
@@ -51,7 +51,8 @@ export function convertFolderTreetoQTree(folders: UIFolder[], notes: UINote[], r
     });
 
     // Find reminders saved in the current folder
-    const remindersInCurrFolder = reminders.filter(reminder => reminder.folderID === folder.folderID && reminder.isSaved);
+    // Do not show generated in file explorer
+    const remindersInCurrFolder = reminders.filter(reminder => reminder.folderID === folder.folderID && reminder.isSaved && !reminder.isGenerated);
 
     // For each reminder, create a QTree node with label and id properties and return it
     const reminderTreeNodes = remindersInCurrFolder.map((reminder) => {
@@ -95,7 +96,7 @@ export function buildRootNodes(folders: UIFolder[],notes: UINote[], reminders: U
     id: -note.itemID,
   }));
 
-  const reminderRootNodes = reminders.filter(reminder => reminder.isSaved && reminder.folderID === 0n).
+  const reminderRootNodes = reminders.filter(reminder => reminder.isSaved && reminder.folderID === 0n && !reminder.isGenerated).
   map(reminder => ({
     label: reminder.title,
     icon: 'alarm',

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-21
+ * Updated: 2025-11-23
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -251,9 +251,14 @@
                         Series end: {{eventDatetoLocaleString(item.recurrence.weekly.seriesEndDate)}}<br>
                       </template>
 
-                       <template v-else-if="item.isRecurring && item.recurrence?.monthly">
+                      <template v-else-if="item.isRecurring && item.recurrence?.monthly">
                         Series start: {{ eventDatetoLocaleString(item.date) }}<br>
                         Series end: {{eventDatetoLocaleString(item.recurrence.monthly.seriesEndDate)}}<br>
+                      </template>
+
+                       <template v-else-if="item.isRecurring && item.recurrence?.yearly">
+                        Series start: {{ eventDatetoLocaleString(item.date) }}<br>
+                        Series end: {{eventDatetoLocaleString(item.recurrence.yearly.seriesEndDate)}}<br>
                       </template>
                       
                       Last modified: {{ item.temporaryLastModified }}
@@ -449,7 +454,7 @@
                   outlined
                   dense
                    style="background-color: #f2f2f2; margin-bottom: 10px"
-                  >
+                  > 
                   <!-- Normalize the visible date picker to be a static month with 31 days -->
                     <template v-slot:append>
                       <q-icon name="event" class="cursor-pointer">
@@ -480,7 +485,46 @@
                   style="background-color: #f2f2f2; margin-bottom: 10px"
                 />
                 </div>
+                <div v-if="item.recurrence.type === 'yearly' && item.recurrence.yearly" style="margin-bottom:8px;">
+                  <q-input
+                  v-model.number="item.recurrence.yearly.timeOfDayMin"
+                  label="Event Time (in minutes into day)"
+                  :min="0"
+                  :max="1439"
+                  type="number"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-input
+                  v-model.number="item.recurrence.yearly.eventDurationMin"
+                  label="Event Duration (in minutes)"
+                  :min="0"
+                  type="number"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-input
+                  v-model="item.recurrence.yearly.dayOfYear"
+                  label="Recurrence Date"
+                  type="date"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                  />
+                 <q-input
+                  v-model="item.recurrence.yearly.seriesEndDate"
+                  label="Series End Date"
+                  type="date"
+                  :min="item.date"
+                  :max="endDateRangeRecurring(item.date)"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
               </div>
+            </div>
               <!-- Hide generic reminders temporary event start and end time for event types -->
               <template v-if="item.eventType !== 1 && item.eventType !== 2 && !item.isRecurring">
               <q-input
@@ -892,7 +936,7 @@
 </template>
 
 <script setup lang="ts">
-import {QCalendarMonth, addToDate, parseTimestamp, today, type Timestamp} from '@quasar/quasar-ui-qcalendar';
+import {QCalendarMonth, addToDate, parseTimestamp, today, isLeapYear, type Timestamp} from '@quasar/quasar-ui-qcalendar';
 import '@quasar/quasar-ui-qcalendar/index.css';
 import {buildCalendarEvents, groupEventsByDate, getEventTypeColor, getEventTypeFields, getEventStartLabel, getEventEndLabel, type EventType, type CalendarEvent} from '../frontend-utils/events';
 import { buildBreadcrumbs, normalizeFolderID, buildRootNodes} from '../frontend-utils/tree';
@@ -1353,13 +1397,14 @@ function onRecurrenceTypeChange(reminder: UIReminder, val: string) {
 
    // Ensure recurrence object exists
   if (!reminder.recurrence) {
+    // If it doesn't exist yet, create it with the type that is set
     reminder.recurrence = { type: val } as UIReminder['recurrence'];
   }
 
-  // Recurrence exists (not null)
+  // Otherwise, recurrence exists (set to not null for typescript)
   const recurrence = reminder.recurrence!;
 
-   // Update the type
+   // Update the type of the recurrence to the dropdown choice
   recurrence.type = val;
 
   // Create matching recurrence object with defaults (daily, weekly, monthly or yearly) according to the selected type if it doesn't exist yet
@@ -1390,6 +1435,15 @@ else if (val === 'weekly' && !recurrence.weekly) {
     notifOffsetTimeMin: null,
     lastDayOfMonth: false,
     daysOfMonth: [], // all days false by default
+    seriesEndDate: '' 
+  }}
+
+  else if (val === 'yearly' && !recurrence.yearly) {
+  recurrence.yearly = { 
+    timeOfDayMin: 0,
+    eventDurationMin: 0,
+    notifOffsetTimeMin: null,
+    dayOfYear: '',
     seriesEndDate: '' 
   }}
 }
@@ -1801,6 +1855,11 @@ async function loadRecurringSeries() {
     for (const recurringMonthlyReminder of monthlyRows) {
       mapDBSeriesToUIRecurringReminder(recurringMonthlyReminder, 'monthly', true);
     } 
+    // Load yearly reminders
+    const yearlyRows = await readYearlyRemindersInRange(startRange, endRange);
+    for (const recurringYearlyReminder of yearlyRows) {
+      mapDBSeriesToUIRecurringReminder(recurringYearlyReminder, 'yearly', true);
+    }
   } catch (error) {
     console.error('Error loading recurring series:', error);
   }
@@ -2069,7 +2128,7 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     recurrence = {
       type: 'daily',
       daily: {
-        timeOfDayMin: dailyReminder.seriesStartMin,
+        timeOfDayMin: dailyReminder.timeOfDayMin,
         eventDurationMin: dailyReminder.eventDurationMin,
         notifOffsetTimeMin: UINotificationOffset,
         everyNDays: dailyReminder.everyNDays,
@@ -2095,7 +2154,7 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     recurrence = {
       type: 'weekly',
       weekly: {
-        timeOfDayMin: weeklyReminder.seriesStartMin,
+        timeOfDayMin: weeklyReminder.timeOfDayMin,
         eventDurationMin: weeklyReminder.eventDurationMin,
         notifOffsetTimeMin: UINotificationOffset,
         everyNWeeks: weeklyReminder.everyNWeeks,
@@ -2121,7 +2180,7 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     recurrence = {
       type: 'monthly',
       monthly: {
-        timeOfDayMin: monthlyReminder.seriesStartMin,
+        timeOfDayMin: monthlyReminder.timeOfDayMin,
         eventDurationMin: monthlyReminder.eventDurationMin,
         notifOffsetTimeMin: UINotificationOffset,
         // When DB value exists, convert to boolean 
@@ -2132,11 +2191,44 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     };
   }
 
+   else if (recurrenceType === 'yearly') {
+    // If recurrence type is yearly, treat DB row as yearly reminder schema
+    const yearlyReminder = row as YearlyReminder;
+    const recurDay = Number(yearlyReminder.dayOfYear);
+    const recurYear = Number(yearlyReminder.seriesStartYear);
+    
+    // Convert dayOfYear from database back to full date string for display
+    // Backend only returns dayOfYear, which does not include the original year the user chose, only day and month
+    // Therefore, use series start year as the display year
+
+    // Make new date on Jan 1st in series start year
+    let recurDate = new Date(recurYear, 0, 1);
+    // Add dayOfYear days to get the correct month/day the user chose
+    recurDate.setDate(recurDate.getDate() + (recurDay - 1));
+    // If dayOfYear is Feb 29 on a leap year, but the series start year isnt a leap year, fallback display date to Feb 28 to not display invalid date
+    if (recurDay == 366 && !isLeapYear(recurYear)) {
+      recurDate = new Date(recurYear, 1, 28);
+    }
+    // Convert date to YYYY-MM-DD string format compatible with qcalendar/selectedDate
+    const recurDateString = `${recurDate.getFullYear()}-${String(recurDate.getMonth() + 1).padStart(2, '0')}-${String(recurDate.getDate()).padStart(2, '0')}`;
+    
+    recurrence = {
+      type: 'yearly',
+      yearly: {
+        timeOfDayMin: yearlyReminder.timeOfDayMin,
+        eventDurationMin: yearlyReminder.eventDurationMin,
+        notifOffsetTimeMin: UINotificationOffset,
+        dayOfYear: normalizeDatePickerToCalendar(recurDateString),
+        seriesEndDate: normalizeDatePickerToCalendar(endDateString) ?? endDateString
+      }
+    };
+  }
+
   // UI reminder extension fields as a record, these are the actual values taken from frontend input fields 
   const extensionsUI = {} as Record<string, string | number | null | undefined>;
 
   // DB reminder row with extensions
-  const extensionsArr = (row as DailyReminder | WeeklyReminder | MonthlyReminder & { extensions?: Extension[] }).extensions;
+  const extensionsArr = (row as DailyReminder | WeeklyReminder | MonthlyReminder | YearlyReminder & { extensions?: Extension[] }).extensions;
 
   // If extensions array exists, map each extension into extensions UI record
   if (extensionsArr && extensionsArr.length > 0) {
@@ -2525,6 +2617,10 @@ async function saveRecurringReminder(reminder: UIReminder) {
   else if (reminder.recurrence.type === 'monthly') {
     return await saveMonthlyReminder(reminder, extensionsToSend);
   }
+   else if (reminder.recurrence.type === 'yearly') {
+    return await saveYearlyReminder(reminder, extensionsToSend);
+  }
+  
   
   // If no matching type, return false
   return false;
@@ -2651,6 +2747,154 @@ async function saveDailyReminder(reminder: UIReminder, extensionsToSend: Extensi
       // Map recurring reminder to UI format
       if (row) {
         mapDBSeriesToUIRecurringReminder(row, 'daily', true);
+      }
+
+      // Remove old normal reminder from UI
+      reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      await loadRemindersForCalendarDate(selectedDate.value);
+      await loadRemindersForMonth(selectedDate.value);
+      reminder.timeMessageError = '';
+      return true;
+    }
+  }
+}
+
+// Function to validate and save weekly recurring reminders
+async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extension[] | undefined): Promise<boolean> {
+  if (!reminder.recurrence?.weekly) {
+    reminder.timeMessageError = 'Weekly recurrence settings are missing.';
+    return false;
+  }
+
+  // Set series times (local to this function)
+  const startTime = normalizeDatePickerToCalendar(reminder.date) ?? reminder.date;
+  const endTime = normalizeDatePickerToCalendar(reminder.recurrence.weekly.seriesEndDate) ?? reminder.recurrence.weekly.seriesEndDate;
+  const seriesStartTime = convertTimeAndDateToTimestamp(startTime, '00:00');
+  const seriesEndTime = convertTimeAndDateToTimestamp(endTime, '23:59');
+
+  // Compare exact moment in time if series start time is before series end time, if not, error
+  const startEpoch = timeStamptoEpoch(seriesStartTime);
+  const endEpoch = timeStamptoEpoch(seriesEndTime);
+  if (endEpoch < startEpoch) {
+    reminder.timeMessageError = 'Start time must be before end time.';
+    return false;
+  }
+
+  // End day must be provided
+  if (!reminder.recurrence.weekly.seriesEndDate) {
+    reminder.timeMessageError = 'Please select a valid event end date for series.';
+    return false;
+  }
+
+  // timeOfDayMin must be between 0 and 1439 (start and end of day)
+  if (!Number.isInteger(reminder.recurrence.weekly.timeOfDayMin) || reminder.recurrence.weekly.timeOfDayMin < 0 || reminder.recurrence.weekly.timeOfDayMin > 1439) {
+    reminder.timeMessageError = 'Event time must be within the start and end of the day (0 to 1439).';
+    return false;
+  }
+
+  // Event duration must be positive (zero for instant event)
+  if (!Number.isInteger(reminder.recurrence.weekly.eventDurationMin) || reminder.recurrence.weekly.eventDurationMin < 0) {
+    reminder.timeMessageError = 'Event duration must be positive (0 for instant events).';
+    return false;
+  }
+
+  // Event duration cannot be more than a day
+  if (reminder.recurrence.weekly.eventDurationMin > 1440) {
+    reminder.timeMessageError = 'Event duration cannot be more than a day.';
+    return false;
+  }
+
+  // everyNWeeks must not be less than 1
+  if (!Number.isInteger(reminder.recurrence.weekly.everyNWeeks) || reminder.recurrence.weekly.everyNWeeks < 1) {
+    reminder.timeMessageError = 'Recurrence interval must be greater than 1.';
+    return false;
+  }
+
+  // Convert day of weeks array into backend 7-char string for database storage
+  // Flag '1' for event that day (selected) and '0' for no event that day (not selected)
+  // Days of week array is set from the q-select dropdown menu containing each days index (ex. [0, 2] where 0 = Sunday, 2 = Tuesday were chosen)
+
+  // Initialize 7-char string as a char array with all 0's (no selection)
+  // ['0', '0', '0', '0', '0', '0', '0'] where all days are unselected by default
+  const daysOfWeekString = Array(7).fill('0');
+
+  // Loop through each selected day of the weeks indices
+  reminder.recurrence.weekly.daysOfWeek.forEach((index) => {
+    // Ensure index is in range
+    if (index >= 0 && index < 7) {
+      // For each selected day, set flag to 1
+      daysOfWeekString[index] = '1';
+    }
+  });
+  // Join char array into a single string to store in database
+  const daysOfWeekDatabaseString = daysOfWeekString.join('');
+
+  // Make sure at least one weekday is selected
+  if (reminder.recurrence.weekly.daysOfWeek.length === 0) {
+    reminder.timeMessageError = 'Please select at least one day of the week for the event to occur.';
+    return false;
+  }
+
+  // Assign variables for DB saving
+  const timeOfDayMin = reminder.recurrence.weekly.timeOfDayMin;
+  const eventDurationMin = reminder.recurrence.weekly.eventDurationMin;
+  // Notification is set as long as its not 'never' (null)
+  const recurringNotifOffset = reminder.recurrence.weekly.notifOffsetTimeMin == null ? 0 : -Math.abs(reminder.recurrence.weekly.notifOffsetTimeMin);
+  const hasNotification = reminder.recurrence.weekly.notifOffsetTimeMin != null;
+  const everyNWeeks = reminder.recurrence.weekly.everyNWeeks;
+  // folderID already checked in saveRecurringReminder, cast to non-null bigint folder ID to save
+  const folderID: bigint = reminder.temporaryFolderID!;
+
+
+  // Recurring reminder not saved to DB yet, create it
+  if (!reminder.isSaved) {
+    const seriesID = await createWeeklyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
+    // Make sure draft ID matches DB ID so it gets replaced in UI
+    reminder.itemID = seriesID;
+    reminder.isSaved = true;
+
+    // Fetch the newly created recurring reminder from the DB
+    const row = await readWeeklyReminder(seriesID);
+
+    // Map recurring reminder to UI format
+    if (row) {
+      mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
+    }
+
+    // Load folders after creation
+    folders.value = mapDBToUIFolder(await readAllFolders());
+    reminder.timeMessageError = '';
+    return true;
+  } else {
+    // Recurring reminder saved before, update it
+    const originalRecurrenceType = reminder.originalRecurrenceType;
+    // Original recurrence type exists, so update existing recurring reminder
+    if (originalRecurrenceType) {
+      await updateWeeklyReminder(reminder.itemID, folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
+
+      // Fetch the updated recurring reminder from the DB
+      const row = await readWeeklyReminder(reminder.itemID);
+
+      // Map recurring reminder to UI format
+      if (row) {
+        mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
+      }
+
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      reminder.timeMessageError = '';
+      return true;
+    } else {
+      // Original recurrence type is null, reminder is normal, convert it to a series
+      // Create new series reminder
+      const seriesID = await createWeeklyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
+      // Delete old normal reminder
+      await deleteItem(reminder.itemID, 12);
+      const row = await readWeeklyReminder(seriesID);
+      // Map recurring reminder to UI format
+      if (row) {
+        mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
       }
 
       // Remove old normal reminder from UI
@@ -2810,16 +3054,15 @@ async function saveMonthlyReminder(reminder: UIReminder, extensionsToSend: Exten
   }
 }
 
-// Function to validate and save weekly recurring reminders
-async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extension[] | undefined): Promise<boolean> {
-  if (!reminder.recurrence?.weekly) {
-    reminder.timeMessageError = 'Weekly recurrence settings are missing.';
+// Function to validate and save yearly recurring reminders
+async function saveYearlyReminder(reminder: UIReminder, extensionsToSend: Extension[] | undefined): Promise<boolean> {
+  if (!reminder.recurrence?.yearly) {
+    reminder.timeMessageError = 'Yearly recurrence settings are missing.';
     return false;
   }
 
-  // Set series times (local to this function)
   const startTime = normalizeDatePickerToCalendar(reminder.date) ?? reminder.date;
-  const endTime = normalizeDatePickerToCalendar(reminder.recurrence.weekly.seriesEndDate) ?? reminder.recurrence.weekly.seriesEndDate;
+  const endTime = normalizeDatePickerToCalendar(reminder.recurrence.yearly.seriesEndDate) ?? reminder.recurrence.yearly.seriesEndDate;
   const seriesStartTime = convertTimeAndDateToTimestamp(startTime, '00:00');
   const seriesEndTime = convertTimeAndDateToTimestamp(endTime, '23:59');
 
@@ -2832,103 +3075,79 @@ async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extens
   }
 
   // End day must be provided
-  if (!reminder.recurrence.weekly.seriesEndDate) {
+  if (!reminder.recurrence.yearly.seriesEndDate) {
     reminder.timeMessageError = 'Please select a valid event end date for series.';
     return false;
   }
 
   // timeOfDayMin must be between 0 and 1439 (start and end of day)
-  if (!Number.isInteger(reminder.recurrence.weekly.timeOfDayMin) || reminder.recurrence.weekly.timeOfDayMin < 0 || reminder.recurrence.weekly.timeOfDayMin > 1439) {
+  if (!Number.isInteger(reminder.recurrence.yearly.timeOfDayMin) || reminder.recurrence.yearly.timeOfDayMin < 0 || reminder.recurrence.yearly.timeOfDayMin > 1439) {
     reminder.timeMessageError = 'Event time must be within the start and end of the day (0 to 1439).';
     return false;
   }
 
   // Event duration must be positive (zero for instant event)
-  if (!Number.isInteger(reminder.recurrence.weekly.eventDurationMin) || reminder.recurrence.weekly.eventDurationMin < 0) {
+  if (!Number.isInteger(reminder.recurrence.yearly.eventDurationMin) || reminder.recurrence.yearly.eventDurationMin < 0) {
     reminder.timeMessageError = 'Event duration must be positive (0 for instant events).';
     return false;
   }
 
   // Event duration cannot be more than a day
-  if (reminder.recurrence.weekly.eventDurationMin > 1440) {
+  if (reminder.recurrence.yearly.eventDurationMin > 1440) {
     reminder.timeMessageError = 'Event duration cannot be more than a day.';
     return false;
   }
+  
+  const recurDate = normalizeDatePickerToCalendar(reminder.recurrence.yearly.dayOfYear).trim();
 
-  // everyNWeeks must not be less than 1
-  if (!Number.isInteger(reminder.recurrence.weekly.everyNWeeks) || reminder.recurrence.weekly.everyNWeeks < 1) {
-    reminder.timeMessageError = 'Recurrence interval must be greater than 1.';
+  if (!recurDate) {
+    reminder.timeMessageError = 'Please select a date for the yearly recurrence.';
     return false;
   }
 
-  // Convert day of weeks array into backend 7-char string for database storage
-  // Flag '1' for event that day (selected) and '0' for no event that day (not selected)
-  // Days of week array is set from the q-select dropdown menu containing each days index (ex. [0, 2] where 0 = Sunday, 2 = Tuesday were chosen)
-
-  // Initialize 7-char string as a char array with all 0's (no selection)
-  // ['0', '0', '0', '0', '0', '0', '0'] where all days are unselected by default
-  const daysOfWeekString = Array(7).fill('0');
-
-  // Loop through each selected day of the weeks indices
-  reminder.recurrence.weekly.daysOfWeek.forEach((index) => {
-    // Ensure index is in range
-    if (index >= 0 && index < 7) {
-      // For each selected day, set flag to 1
-      daysOfWeekString[index] = '1';
-    }
-  });
-  // Join char array into a single string to store in database
-  const daysOfWeekDatabaseString = daysOfWeekString.join('');
-
-  // Make sure at least one weekday is selected
-  if (reminder.recurrence.weekly.daysOfWeek.length === 0) {
-    reminder.timeMessageError = 'Please select at least one day of the week for the event to occur.';
+  // Convert day of year to recur on to timestamp to store in database
+  // 00:00 time because only the date is used from this field
+  const recurDayTimestamp = convertTimeAndDateToTimestamp(recurDate, '00:00');
+  if (!recurDayTimestamp) {
+    reminder.timeMessageError = 'Invalid recurrence date.';
     return false;
   }
 
-  // Assign variables for DB saving
-  const timeOfDayMin = reminder.recurrence.weekly.timeOfDayMin;
-  const eventDurationMin = reminder.recurrence.weekly.eventDurationMin;
-  // Notification is set as long as its not 'never' (null)
-  const recurringNotifOffset = reminder.recurrence.weekly.notifOffsetTimeMin == null ? 0 : -Math.abs(reminder.recurrence.weekly.notifOffsetTimeMin);
-  const hasNotification = reminder.recurrence.weekly.notifOffsetTimeMin != null;
-  const everyNWeeks = reminder.recurrence.weekly.everyNWeeks;
-  // folderID already checked in saveRecurringReminder, cast to non-null bigint folder ID to save
-  const folderID: bigint = reminder.temporaryFolderID!;
+  // Assign local variables for DB saving
+  const timeOfDayMin = reminder.recurrence.yearly.timeOfDayMin;
+  const eventDurationMin = reminder.recurrence.yearly.eventDurationMin;
+  const recurringNotifOffset = reminder.recurrence.yearly.notifOffsetTimeMin == null ? 0 : -Math.abs(reminder.recurrence.yearly.notifOffsetTimeMin);
+  const hasNotification = reminder.recurrence.yearly.notifOffsetTimeMin != null;
+  const folderID: bigint = reminder.temporaryFolderID!; 
 
-
-  // Recurring reminder not saved to DB yet, create it
+   // Recurring reminder not saved to DB yet, create it
   if (!reminder.isSaved) {
-    const seriesID = await createWeeklyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
-    // Make sure draft ID matches DB ID so it gets replaced in UI
+    const seriesID = await createYearlyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, recurDayTimestamp, reminder.temporaryTitle, extensionsToSend);
     reminder.itemID = seriesID;
     reminder.isSaved = true;
 
     // Fetch the newly created recurring reminder from the DB
-    const row = await readWeeklyReminder(seriesID);
+    const row = await readYearlyReminder(seriesID);
 
     // Map recurring reminder to UI format
     if (row) {
-      mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
+      mapDBSeriesToUIRecurringReminder(row, 'yearly', true);
     }
 
-    // Load folders after creation
     folders.value = mapDBToUIFolder(await readAllFolders());
     reminder.timeMessageError = '';
     return true;
   } else {
     // Recurring reminder saved before, update it
     const originalRecurrenceType = reminder.originalRecurrenceType;
-    // Original recurrence type exists, so update existing recurring reminder
     if (originalRecurrenceType) {
-      await updateWeeklyReminder(reminder.itemID, folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
-
+      // Update existing series in DB
+      await updateYearlyReminder(reminder.itemID, folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, recurDayTimestamp, reminder.temporaryTitle, extensionsToSend);
       // Fetch the updated recurring reminder from the DB
-      const row = await readWeeklyReminder(reminder.itemID);
-
+      const row = await readYearlyReminder(reminder.itemID);
       // Map recurring reminder to UI format
       if (row) {
-        mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
+        mapDBSeriesToUIRecurringReminder(row, 'yearly', true);
       }
 
       folders.value = mapDBToUIFolder(await readAllFolders());
@@ -2937,18 +3156,17 @@ async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extens
     } else {
       // Original recurrence type is null, reminder is normal, convert it to a series
       // Create new series reminder
-      const seriesID = await createWeeklyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
+      const seriesID = await createYearlyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, recurDayTimestamp, reminder.temporaryTitle, extensionsToSend);
       // Delete old normal reminder
       await deleteItem(reminder.itemID, 12);
-      const row = await readWeeklyReminder(seriesID);
-      // Map recurring reminder to UI format
+      const row = await readYearlyReminder(seriesID);
       if (row) {
-        mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
+        mapDBSeriesToUIRecurringReminder(row, 'yearly', true);
       }
 
-      // Remove old normal reminder from UI
+      // Remove old normal reminder from UI list
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
-
+      // Map recurring reminder to UI format
       folders.value = mapDBToUIFolder(await readAllFolders());
       await loadRemindersForCalendarDate(selectedDate.value);
       await loadRemindersForMonth(selectedDate.value);
@@ -3000,7 +3218,6 @@ async function saveReminder(reminder: UIReminder){
  }
 
   // Continue with normal reminder saving
-  
   const extension = reminder.extension ?? {};
 
   // Helper function to safely read string/time fields from extension record (as they are optional they can be missing or empty)
@@ -3428,6 +3645,12 @@ async function cancelReminder(reminder: UIReminder) {
         const row = await readMonthlyReminder(reminder.itemID);
         if (row) {
           mapDBSeriesToUIRecurringReminder(row, 'monthly', true)
+        }
+      }
+      else if (originalRecurrenceType === 'yearly') {
+        const row = await readYearlyReminder(reminder.itemID);
+        if (row) {
+          mapDBSeriesToUIRecurringReminder(row, 'yearly', true)
         }
       }
     } 

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -2314,6 +2314,40 @@ async function deleteReminder(reminder: UIReminder) {
   //reminders.value = reminders.value.filter(reminder => !reminder.isSelected);
 }
 
+// Function to delete selected recurring reminders
+async function deleteRecurringReminderSeries(reminder: UIReminder) {
+  try {
+    // Validate that the reminder is recurring
+    if (!reminder.recurrence || !reminder.isRecurring) {
+      console.error('Reminder is not recurring:', reminder.itemID);
+      return;
+    }
+
+    // Delete recurring series using its types table number
+    // Deleting a series automatically deletes all its generated reminders 
+    if (reminder.recurrence.type === 'daily') {
+     await deleteItem(reminder.itemID, 21);
+   } else if (reminder.recurrence.type === 'weekly') {
+     await deleteItem(reminder.itemID, 22);
+   } else if (reminder.recurrence.type === 'monthly') {
+     await deleteItem(reminder.itemID, 23);
+   } else if (reminder.recurrence.type === 'yearly') {
+     await deleteItem(reminder.itemID, 24);
+   } else {
+    // Not a valid recurrence type
+     return;
+   }
+    // Update reminders array to filter out deleted reminder
+    // Array only contains reminders where the itemID does not match the deleted reminder's itemID
+    reminders.value = reminders.value.filter(r => r.itemID !== reminder.itemID);
+   // Successful deletion, refresh file explorer
+   folders.value = mapDBToUIFolder(await readAllFolders());
+  } catch (error) {
+    console.error('Error deleting recurring reminder series from DB:', error);
+  }
+} 
+
+
 // Function to delete selected individual checkbox notes
 async function deleteNote(note: UINote) {
   try {
@@ -2423,8 +2457,13 @@ async function deleteArrayItem() {
   if (tab.value === 'reminders') {
     // Delete all selected reminders by calling deleteReminder for each selected item
     const selectedReminders = reminders.value.filter(reminder => reminder.isSelected);
+    // Call appropriate delete function dependent on if reminder is recurring or not
     for (const reminder of selectedReminders) {
-      await deleteReminder(reminder);
+      if (reminder.isRecurring) {
+        await deleteRecurringReminderSeries(reminder);
+      } else {
+        await deleteReminder(reminder);
+      }
     }
   } else if (tab.value === 'notes') {
     // Delete all selected notes by calling deleteNote for each selected item
@@ -2502,13 +2541,18 @@ const filteredReminders = computed(() => {
   // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
   const query = (searchQuery.value ?? '').trim().toLowerCase();
 
+  // Filter out recurring reminders from reminder list for middle list display
+  // Only when not saved, must allow drafts to create the recurrence
+  //const noRecurringReminders = reminders.value.filter(reminder => !reminder.isRecurring || !reminder.isSaved);
+  const noRecurringReminders = reminders.value;
+
   if (!searchQuery.value) {
     // If no search query, default show reminders for selected calendar date
-    return reminders.value.filter(reminder => reminder.date === selectedDate.value);
+    return noRecurringReminders.filter(reminder => reminder.date === selectedDate.value);
   }
 
   // Otherwise, filter reminders based on the search query (title)
-  return reminders.value.filter(reminder => {
+  return noRecurringReminders.filter(reminder => {
     // Check for reminders entries where the title is in the search query
     const matchesQuery = String(reminder.temporaryTitle ?? '').toLowerCase().includes(query) || String(reminder.title ?? '').toLowerCase().includes(query);
     // Return true if both date and query match

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -947,9 +947,9 @@
 
 <script setup lang="ts">
 // Imports
-import {QCalendarMonth, addToDate, parseTimestamp, today, isLeapYear, type Timestamp} from '@quasar/quasar-ui-qcalendar';
+import { QCalendarMonth, addToDate, parseTimestamp, today, isLeapYear, type Timestamp } from '@quasar/quasar-ui-qcalendar';
 import '@quasar/quasar-ui-qcalendar/index.css';
-import {buildCalendarEvents, groupEventsByDate, getEventTypeColor, getEventTypeFields, getEventStartLabel, stripNulls, getEventEndLabel, type EventType, type CalendarEvent} from '../frontend-utils/events';
+import { buildCalendarEvents, groupEventsByDate, getEventTypeColor, getEventTypeFields, getEventStartLabel, stripNulls, getEventEndLabel, type EventType, type CalendarEvent } from '../frontend-utils/events';
 import { buildBreadcrumbs, normalizeFolderID, buildRootNodes} from '../frontend-utils/tree';
 import { convertTimeAndDateToTimestamp, convertNotificationTimestamp, minutesToHHMM, timeStamptoEpoch, normalizeDatePickerToCalendar, eventDatetoLocaleString, endDateRange, endDateRangeRecurring } from '../frontend-utils/time';
 import { ref, computed, watch, onMounted } from 'vue';
@@ -958,7 +958,7 @@ import type { Reminder, DailyReminder, WeeklyReminder, MonthlyReminder, YearlyRe
 import {createNote, createReminder, createDailyReminder, createWeeklyReminder, createMonthlyReminder, createYearlyReminder, createOrUpdateOverride, createFolder, createRootFolder,
   readNote, readNotesInRange, readReminder, readDailyReminder, readWeeklyReminder, readMonthlyReminder, readYearlyReminder, readRemindersInRange, readDailyRemindersInRange, readWeeklyRemindersInRange, readMonthlyRemindersInRange, readYearlyRemindersInRange, readGeneratedRemindersInRange, readAllFolders, 
   updateNote, updateReminder, updateDailyReminder, updateWeeklyReminder, updateMonthlyReminder, updateYearlyReminder, updateFolder, 
-  deleteItem, deleteFolder} from '../utils/local-db';
+  deleteItem, deleteFolder } from '../utils/local-db';
 import { FieldsToFlight, FieldsToHotel, FlightToExtensions, HotelToExtensions, ExtensionsToFlight, ExtensionsToHotel } from '../utils/eventtypes';
 import { useQuasar } from 'quasar';
 import { useRouter } from 'vue-router';
@@ -2187,6 +2187,7 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
     extension: extensionsUI,
     // Normal reminders have no recurrence type
     originalRecurrenceType: null,
+    originalGeneratedTimestamp: null,
     temporaryEventStartTime: startStr,
     temporaryEventEndTime: endStr,
     temporaryEventEndDay: normalizeDatePickerToCalendar(endDateString) ?? dateString, // Default end day is same as start day (not multi-day)
@@ -2256,6 +2257,19 @@ function mapDBGeneratedToUIReminder(row: GeneratedReminder, upsert: boolean): UI
   const eventEndMinute = endMinuteOfDay % 60;
   endDate.setHours(eventEndHour, eventEndMinute, 0, 0);
   const endDateString = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}`;
+
+
+  // Create a timestamp from original DB year, day, min to use in overrides
+  const originalMinuteOfDay = Number(row.origEventStartMin);
+  const originalDay = Number(row.origEventStartDay);
+  const originalYear = Number(row.origEventStartYear);
+  const originalDate = new Date(originalYear, 0, 1);
+  originalDate.setDate(originalDate.getDate() + (originalDay - 1));
+  const origTimeString = minutesToHHMM(originalMinuteOfDay);
+  const origDateString = `${originalDate.getFullYear()}-${String(originalDate.getMonth() + 1).padStart(2, '0')}-${String(originalDate.getDate()).padStart(2, '0')}`;
+  // Convert date to timestamp
+  const originalTimestamp = convertTimeAndDateToTimestamp(origDateString, origTimeString);
+
 
   // UI reminder extension fields as a record, these are the actual values taken from frontend input fields 
   const extensionsUI = {} as Record<string, string | number | null | undefined>;
@@ -2333,6 +2347,7 @@ function mapDBGeneratedToUIReminder(row: GeneratedReminder, upsert: boolean): UI
     extension: extensionsUI,
     // Normal reminders have no recurrence type
     originalRecurrenceType: null,
+    originalGeneratedTimestamp: originalTimestamp,
     temporaryEventStartTime: startStr,
     temporaryEventEndTime: endStr,
     temporaryEventEndDay: normalizeDatePickerToCalendar(endDateString) ?? dateString, // Default end day is same as start day (not multi-day)
@@ -2568,6 +2583,7 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     extension: extensionsUI,
     // Get recurrence type from DB row loaded into the UI
     originalRecurrenceType: recurrence?.type ?? recurrenceType,
+    originalGeneratedTimestamp: null,
     // Event start time, end time, end day, end date are all unique to non-recurring reminders, override these fields for recurring 
     temporaryEventStartTime: '',
     temporaryEventEndTime: '',
@@ -2585,7 +2601,6 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     notifDay: 0,
     notifMin: 0,
     hasNotif: row.hasNotifs,
-
     temporaryLastModified: lastModifiedTimeAndDate,
     date: normalizeDatePickerToCalendar(dateString) ?? dateString,
     titleMessageError: '',
@@ -3539,6 +3554,12 @@ async function saveReminder(reminder: UIReminder){
     return;
   }
 
+  // Reminder is generated, create/update an override on save
+  if (reminder.isGenerated) {
+    await saveGeneratedReminder(reminder);
+    return;
+  }
+
   // If recurring reminder returned false by failing validation, stop
    if (!recurringReminder && reminder.timeMessageError) {
    return;
@@ -3742,6 +3763,42 @@ try {
   }
   } catch (error) {
     console.error('Error adding reminder:', error);
+  }
+}
+
+// Function to create or update an override when generated reminder is saved
+async function saveGeneratedReminder(generatedReminder: UIReminder) {
+  try {
+    // Not a generated reminder
+    if (!generatedReminder || !generatedReminder.isGenerated || !generatedReminder.linkedParentSeriesID
+    ) {
+      return;
+    }
+
+    const originalStartTimestamp = generatedReminder.originalGeneratedTimestamp;
+    if (!originalStartTimestamp) {
+      return;
+    }
+
+    // Create newly edited generated fields from UI fields (event start/end time, notifTime, and hasNotif)
+    // Keep time on same day as the generated reminder date
+    const eventStartTime = convertTimeAndDateToTimestamp(generatedReminder.date, generatedReminder.temporaryEventStartTime ?? '00:00');
+    const eventEndTime = convertTimeAndDateToTimestamp(generatedReminder.date, generatedReminder.temporaryEventEndTime ?? '00:00');
+
+    // Use notification offset
+    const notifOffsetMin = generatedReminder.temporaryNotificationTime;
+    const hasNotif = notifOffsetMin != null;
+    const notifTimestamp = hasNotif
+      ? convertNotificationTimestamp(generatedReminder.date, generatedReminder.temporaryEventStartTime ?? '00:00', Number(generatedReminder.temporaryNotificationTime))
+      : eventStartTime; // Placeholder if no notification
+
+    // Create override
+    await createOrUpdateOverride(generatedReminder.linkedParentSeriesID, originalStartTimestamp, eventStartTime, eventEndTime, notifTimestamp, hasNotif);
+    // Reload generated reminders to show updated fields
+    await loadGeneratedReminders(selectedDate.value);
+
+  } catch (error) {
+    console.error('Error saving generated reminder override:', error);
   }
 }
 

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-25
+ * Updated: 2025-11-26
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -917,7 +917,7 @@
                 outlined
                 style="background-color: #f2f2f2; margin-bottom: 10px"
               />
-                <q-input class="note-box" outlined v-model="item.temporaryText" type="textarea" maxlength="64"
+                <q-input class="note-box" outlined v-model="item.temporaryText" type="textarea" 
                   placeholder="Write your note here..." />
                 <div class="row">
                   <!-- Pass in current note item from v-for to save that specific note -->
@@ -1188,16 +1188,16 @@ const daysOfWeekOptions = [
     // If reminder is recurring, bind to notifOffsetTimeMin
     if (reminder.recurrence) {
       if (reminder.recurrence.type === 'daily' && reminder.recurrence.daily) {
-        return reminder.recurrence.daily.notifOffsetTimeMin ?? null;
+         return reminder.recurrence.daily.notifOffsetTimeMin == null ? null : Math.abs(reminder.recurrence.daily.notifOffsetTimeMin);
       }
       else if (reminder.recurrence.type === 'weekly' && reminder.recurrence.weekly) {
-        return reminder.recurrence.weekly.notifOffsetTimeMin ?? null;
+        return reminder.recurrence.weekly.notifOffsetTimeMin == null ? null : Math.abs(reminder.recurrence.weekly.notifOffsetTimeMin);
       }
       else if (reminder.recurrence.type === 'monthly' && reminder.recurrence.monthly) {
-        return reminder.recurrence.monthly.notifOffsetTimeMin ?? null;
+        return reminder.recurrence.monthly.notifOffsetTimeMin == null ? null : Math.abs(reminder.recurrence.monthly.notifOffsetTimeMin);
       }
       else if (reminder.recurrence.type === 'yearly' && reminder.recurrence.yearly) {
-        return reminder.recurrence.yearly.notifOffsetTimeMin ?? null;
+        return reminder.recurrence.yearly.notifOffsetTimeMin == null ? null : Math.abs(reminder.recurrence.yearly.notifOffsetTimeMin);
       }
       // For any other recurrence type, return null (should not get here)
       return null;
@@ -1210,19 +1210,19 @@ const daysOfWeekOptions = [
 
   // When user changes notification offset dropdown (val), update the correct field in the reminder
   function setNotificationOffset(reminder: UIReminder, val: number| null) {
-    // If reminder is recurring, update notifOffsetTimeMin feidl to updated value
+    // If reminder is recurring, update notifOffsetTimeMin field to updated value
     if (reminder.recurrence) {
       if (reminder.recurrence.type === 'daily' && reminder.recurrence.daily) {
-        reminder.recurrence.daily.notifOffsetTimeMin = val;
+        reminder.recurrence.daily.notifOffsetTimeMin = val == null? null : Math.abs(val);
       }
       else if (reminder.recurrence.type === 'weekly' && reminder.recurrence.weekly) {
-        reminder.recurrence.weekly.notifOffsetTimeMin = val;
+        reminder.recurrence.weekly.notifOffsetTimeMin = val == null? null : Math.abs(val);
       }
       else if (reminder.recurrence.type === 'monthly' && reminder.recurrence.monthly) {
-        reminder.recurrence.monthly.notifOffsetTimeMin = val;
+        reminder.recurrence.monthly.notifOffsetTimeMin = val == null? null : Math.abs(val);
       }
       else if (reminder.recurrence.type === 'yearly' && reminder.recurrence.yearly) {
-        reminder.recurrence.yearly.notifOffsetTimeMin = val;
+        reminder.recurrence.yearly.notifOffsetTimeMin = val == null? null : Math.abs(val);
       }
     } else {
       // If reminder is not recurring, update temporaryNotificationTime field to updated value

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -875,7 +875,7 @@
                   <q-btn class="login-register-button" style="font-size: 15px; margin-right: 10px" flat label="Save" @click="saveReminder(item)"></q-btn>
                   <q-btn v-if="!item.isGenerated" class="login-register-button" style="background-color: grey; font-size: 15px" flat label="Cancel" @click="cancelReminder(item)"></q-btn>
                   <q-btn v-if="item.isGenerated" class="login-register-button" style="font-size: 15px" flat label="View Series" @click="showParentSeriesFromGeneratedReminder(item)"></q-btn>
-                  <q-btn v-if="item.isRecurring && previousListState && String(previousListState.parentSeriesID) === String(item.itemID)" class="login-register-button" style="background-color: grey; font-size: 15px" flat label="View Generated" @click="showGeneratedReminderFromParentSeries()"></q-btn>
+                  <q-btn v-if="item.isRecurring && previousListState && String(previousListState.parentSeriesID) === String(item.itemID)" class="login-register-button" style="background-color: grey; font-size: 15px; margin-left: 10px;"  flat label="View Generated" @click="showGeneratedReminderFromParentSeries()"></q-btn>
                 </div>
               </q-card-section>
             </q-expansion-item>

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-23
+ * Updated: 2025-11-24
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -212,11 +212,13 @@
             <q-expansion-item v-model="item.expanded" expand-icon="keyboard_arrow_down">
               <template v-slot:header>
                   <div class="reminder-header-container">
+                    <!--- Title is readonly and not editable for a generated reminder. Generated titles stay the same as its parent series title. -->
                     <q-checkbox :color="getEventTypeColor(eventTypes, item.eventType)" v-model="item.isSelected" class="q-mr-sm" />
                     <q-input
                       v-model="item.temporaryTitle"
                       :error="item.titleMessageError != ''"
                       :error-message="item.titleMessageError"
+                      :readonly="item.isGenerated"
                       placeholder="Enter reminder title..."
                       borderless
                       dense
@@ -226,8 +228,8 @@
                       maxlength="48"
                       />
                     </div>
-              </template>
-              <q-card-section>
+                    </template>
+                    <q-card-section>
                      <div style="padding-bottom:10px">
                       <!-- Single-day non-recurring reminder -->
                       <template v-if="!item.isRecurring && !item.temporaryEventEndDateEnabled">
@@ -261,10 +263,16 @@
                         Series end: {{eventDatetoLocaleString(item.recurrence.yearly.seriesEndDate)}}<br>
                       </template>
                       
+                      <template v-if="!item.isGenerated">
                       Last modified: {{ item.temporaryLastModified }}
+                      </template>
+
+                      <div v-if="item.isGenerated">
+                      This is a generated reminder from a recurring series. Title, folder, and event type are not editable.
+                      </div>
                     </div>
                 <q-checkbox
-                  v-if="!item.isRecurring"
+                  v-if="!item.isRecurring && !item.isGenerated"
                   v-model="item.temporaryEventEndDateEnabled"
                   label="Multi‑day"
                   dense
@@ -274,7 +282,7 @@
                 />
                 <br>
                 <q-checkbox
-                   v-if="!item.temporaryEventEndDateEnabled"
+                   v-if="!item.temporaryEventEndDateEnabled && !item.isGenerated"
                   v-model="item.isRecurring"
                   @update:model-value="val => onToggleRecurrenceType(item, val)"
                   label="Recurring"
@@ -286,6 +294,7 @@
                 <q-select
                 v-model="item.eventType"
                 :options="eventTypeOptions"
+                :disable="item.isGenerated"
                 label="Event Type"
                 emit-value
                 map-options
@@ -296,6 +305,7 @@
                 <q-select
                 v-model="item.temporaryFolderID"
                 :options="folderDropdownOptions"
+                :disable="item.isGenerated"
                 label="Save in folder"
                 emit-value 
                 map-options
@@ -897,23 +907,21 @@
                 @click-date="onClickDate" @click-day="onClickDay" @click-workweek="onClickWorkweek"
                 @click-head-workweek="onClickHeadWorkweek" @click-head-day="onClickHeadDay" style="height: 400px;" >
                 <template #day="{ scope: { timestamp } }">
+                <div style="display: flex; flex-direction: column; gap: 3px; padding: 2px; align-items: center; justify-content: center;">
               <template v-for="event in eventsMap[timestamp.date]" :key="String(event.id)">
                 <div
-                  :class="['text-white', `bg-${event.color}`, 'row', 'justify-start', 'items-center',  'event-card']"
-                  style="width: 100%; margin: 1px 0 0 0; padding: 0 6px; font-size: 12px; cursor: pointer;"
-                  @click="onClickCalendarEvent(event)"
-                >
-                  <q-icon :name="event.icon || 'access_time'" size="14px" class="q-mr-xs" />
-                  <div class="event-title" style="width: 100%; max-width: 100%;">
-                  {{ event.title}}
-                  </div>
+                :class="`bg-${event.color}`"
+                style="width: 8px; height: 8px; border-radius: 50%; cursor: pointer;"
+                @click="onClickCalendarEvent(event)"
+              >
                 <!-- Tooltip on hover to clarify if event start or end -->
                 <q-tooltip v-if="event.isStart || event.isEnd">
                   <!-- If single day, combined start and end labels. If multi-day start and end separate labels. -->
-                  {{ (event.isStart && event.isEnd) ? 'Event start & end' : (event.isStart ? 'Event start' : 'Event end') }}
+                  {{ (event.isStart && event.isEnd) ? `${event.title} event` : (event.isStart ? `${event.title} event start` : `${event.title} event end`) }}
                 </q-tooltip>
                 </div>
               </template>
+              </div>
             </template>
               </q-calendar-month>
             </div>
@@ -943,7 +951,7 @@ import { buildBreadcrumbs, normalizeFolderID, buildRootNodes} from '../frontend-
 import { convertTimeAndDateToTimestamp, convertNotificationTimestamp, minutesToHHMM, timeStamptoEpoch, normalizeDatePickerToCalendar, eventDatetoLocaleString } from '../frontend-utils/time';
 import { ref, computed, watch, onMounted } from 'vue';
 import type { UINote, UIReminder, UIFolder } from '../types/ui-types';
-import type { Reminder, DailyReminder, WeeklyReminder, MonthlyReminder, YearlyReminder, Note, Folder, Extension } from '../../src-electron/types/shared-types';
+import type { Reminder, DailyReminder, WeeklyReminder, MonthlyReminder, YearlyReminder, GeneratedReminder, Note, Folder, Extension } from '../../src-electron/types/shared-types';
 import {createNote, createReminder, createDailyReminder, createWeeklyReminder, createMonthlyReminder, createYearlyReminder, createOrUpdateOverride, createFolder, createRootFolder,
   readNote, readNotesInRange, readReminder, readDailyReminder, readWeeklyReminder, readMonthlyReminder, readYearlyReminder, readRemindersInRange, readDailyRemindersInRange, readWeeklyRemindersInRange, readMonthlyRemindersInRange, readYearlyRemindersInRange, readGeneratedRemindersInRange, readAllFolders, 
   updateNote, updateReminder, updateDailyReminder, updateWeeklyReminder, updateMonthlyReminder, updateYearlyReminder, updateFolder, 
@@ -956,7 +964,6 @@ import { ValidateFlight, ValidateHotel } from '../utils/validate';
 // Initialize active tab to reminder by default
 const tab = ref('reminders');
 const settingsTab = ref('cloud');
-// Array of reminders 
 const reminders = ref<UIReminder[]>([])
 // Array of reminders by month for calendar
 const monthReminders = ref<UIReminder[]>([])
@@ -1700,6 +1707,7 @@ function addReminder() {
     temporaryLastModified: new Date().toLocaleString(),
     temporaryTitle: '',
     temporaryFolderID: folderID,
+    temporaryEventEndDateEnabled: false,
     date: selectedDate.value,
     titleMessageError: '',
     folderMessageError: '',
@@ -1708,9 +1716,10 @@ function addReminder() {
     isEditing: false,
     isSelected: false,
     expanded: true,
-    temporaryEventEndDateEnabled: false,
     isRecurring: false,
-    isConverting: false
+    isConverting: false,
+    isGenerated: false,
+    linkedParentSeriesID: null
   } as UIReminder;
 
   // Add draft reminder to reminders array for UI rendering
@@ -1800,6 +1809,89 @@ async function loadRemindersForMonth(dateString: string) {
         // console.log('Reminders for month successfully loaded:');
       }
     } catch (error) {
+    console.error('Error loading reminders for month:', error);
+  } 
+}
+
+// Load generated reminders for the current viewable calendar month + next month
+async function loadGeneratedReminders(dateString: string) {
+// Split date string by delimiter '-' to get each part (year, month, day)
+  const [yearString, monthString, dayString] = dateString.split('-');
+  const year = Number(yearString);
+  const month = Number(monthString);
+  const day = Number(dayString);
+
+  // Check for invalid month
+  if (month < 1 || month > 12) {
+    console.error('Invalid month value:', month);
+    return;
+  }
+
+  // Check for invalid day
+  if (day < 1 || day > 31) {
+    console.error('Invalid day value:', day);
+    return;
+  }
+
+  // Check for invalid year
+  if (year < 1) {
+    console.error('Invalid year value:', year);
+    return;
+  }
+
+  // Build start and end timestamps to load in range (from first day to last day of month)
+  // First day of the month - ex. 2025-11-01
+  const startDayOfMonth= `${year}-${String(month).padStart(2, '0')}-01`;
+  // Last day of the month - ex. 2025-11-30
+  // Date returns the day before the first day of the next month (always the last day - ex. 30 for Nov, 31 for Dec, 28 for Feb)
+  const lastDayOfMonth = new Date(year, month, 0).getDate();
+  const lastDayString = `${year}-${String(month).padStart(2, '0')}-${String(lastDayOfMonth).padStart(2, '0')}`;
+
+  // Convert to qcalendar timestamps
+  const startRange = convertTimeAndDateToTimestamp(startDayOfMonth, '');
+  const endRange = convertTimeAndDateToTimestamp(lastDayString, '23:59');
+
+  // Build start and end timestamps for next month 
+  // This is necessary because notifications are only scheduled for generated reminders on frontend read
+  // If month is December, roll over to January of the next year. Otherwise, increment the month and stay in the year
+  const nextMonth = (month === 12) ? 1 : month + 1;
+  const nextYear = (month === 12) ? year + 1 : year;
+  const nextMonthStartDay = `${nextYear}-${String(nextMonth).padStart(2, '0')}-01`;
+  const nextMonthLastDay = new Date(nextYear, nextMonth, 0).getDate();
+  const nextMonthLastDayString = `${nextYear}-${String(nextMonth).padStart(2, '0')}-${String(nextMonthLastDay).padStart(2, '0')}`;
+  const nextMonthStartRange = convertTimeAndDateToTimestamp(nextMonthStartDay, '');
+  const nextMonthEndRange = convertTimeAndDateToTimestamp(nextMonthLastDayString, '23:59');
+
+  try {
+    // Clear existing generated reminders before reloading to avoid duplicates
+    reminders.value = reminders.value.filter(reminder => !reminder.isGenerated);
+    monthReminders.value = monthReminders.value.filter(reminder => !reminder.isGenerated);
+
+    // Read the viewable calendar month
+    const currentMonthReminders = await readGeneratedRemindersInRange(startRange, endRange);
+    console.log('📅 Current month generated reminders from DB:', currentMonthReminders.length, currentMonthReminders); // DEBUG
+    // Convert each generated reminder in range from response to UI reminder format 
+    for (const generatedReminder of currentMonthReminders) {
+      // Map to UI and push to middle list (reminders array)
+      const result = mapDBGeneratedToUIReminder(generatedReminder, true);
+      // Push generated reminder to current month calendar view
+      monthReminders.value.push(result);
+    }
+
+    // Read the next month after
+    const nextMonthReminders = await readGeneratedRemindersInRange(nextMonthStartRange, nextMonthEndRange);
+     console.log('📅 Next month generated reminders from DB:', nextMonthReminders.length, nextMonthReminders); // DEBUG
+    // Convert each generated reminder in range from response to UI reminder format
+    for (const generatedReminder of nextMonthReminders) {
+      // Map to UI and push to middle list (reminders array)
+      // Do not push to monthReminders since its not in the current month view
+      mapDBGeneratedToUIReminder(generatedReminder, true);
+    }
+
+    console.log('✅ Total generated reminders in reminders.value:', reminders.value.filter(r => r.isGenerated).length); // DEBUG
+    console.log('Generated reminders:', reminders.value.filter(r => r.isGenerated)); // DEBUG
+
+  } catch (error) {
     console.error('Error loading reminders for month:', error);
   } 
 }
@@ -1932,7 +2024,7 @@ function stripNulls(fieldString?: string | null): string {
 // Map a DB reminder row into the UI reminder shape needed for card display
 // Additional upsert parameter decides whether to add/update the global reminders array
 function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
-  // Create a date in local timezone from DB row for UI so filtered reminder/note list only shows entries whose event date match the calendar date
+  // Create a date in local timezone from DB row for UI so filtered reminderlist only shows entries whose event date match the calendar date
   // Get minute of day, event day, and event year from DB row
   const minuteOfDay = Number(row.eventStartMin);
   const eventDay = Number(row.eventStartDay);
@@ -2062,6 +2154,8 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
     isSelected: false,
     isRecurring: false,
     isConverting: false,
+    isGenerated: false,
+    linkedParentSeriesID: null,
     expanded: true
   } as UIReminder;
 
@@ -2080,6 +2174,154 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
 }
   return UIReminder;
 }
+
+// Map a DB generated reminder row into the UI reminder shape needed for card display
+// Additional upsert parameter decides whether to add/update the global reminders array
+function mapDBGeneratedToUIReminder(row: GeneratedReminder, upsert: boolean): UIReminder {
+  // Create a date in local timezone from DB row for UI so filtered reminder list only shows entries whose event date match the calendar date
+  // Get minute of day, event day, and event year from DB row
+  const minuteOfDay = Number(row.eventStartMin);
+  const eventDay = Number(row.eventStartDay);
+  const eventYear = Number(row.eventStartYear);
+  // Start at january 1st of event year and add days to get the right month/day
+  const date = new Date(eventYear, 0, 1);
+  // Set date object to event day
+  date.setDate(date.getDate() + (eventDay - 1));
+  // Calculate hours: divide number of minutes by 60 to get hours
+  // Floor to return actual integer hour, no decimals
+  const eventHour = Math.floor(minuteOfDay / 60);
+  // Calculate remaining minutes: take minutes and modulo 60 (remainder is number of minutes)
+  const eventMinute = minuteOfDay % 60;
+  // Set hours and minutes of date object
+  date.setHours(eventHour, eventMinute, 0, 0);
+  // Convert date to YYYY-MM-DD string format compatible with qcalendar/selectedDate
+  // getMonth returns zero-based index add 1 to get actual month number
+  // Pad month and day so its always two digits - ex. day 5 becomes 05
+  const dateString = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+
+  const endMinuteOfDay = Number(row.eventEndMin);
+  const endEventDay = Number(row.eventEndDay);
+  const endEventYear = Number(row.eventEndYear);
+  const endDate = new Date(endEventYear, 0, 1);
+  endDate.setDate(endDate.getDate() + (endEventDay - 1));
+  const eventEndHour = Math.floor(endMinuteOfDay / 60);
+  const eventEndMinute = endMinuteOfDay % 60;
+  endDate.setHours(eventEndHour, eventEndMinute, 0, 0);
+  const endDateString = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}`;
+
+  // UI reminder extension fields as a record, these are the actual values taken from frontend input fields 
+  const extensionsUI = {} as Record<string, string | number | null | undefined>;
+
+  // DB reminder row with extensions
+  const extensionsArr = (row as GeneratedReminder & { extensions?: Extension[] }).extensions;
+
+  // Derive HH:MM time strings for display from database stored minutes of day value
+  // Convert event start and end min into HH:MM string
+  let startStr = (typeof row.eventStartMin === 'number') ? minutesToHHMM(row.eventStartMin) : '';
+  let endStr = (typeof row.eventEndMin === 'number') ? minutesToHHMM(row.eventEndMin) : '';
+
+  if (!startStr) {
+    startStr = '';
+  }
+  if (!endStr) {
+    endStr = '';
+  }
+
+  const eventStartMin = typeof row.eventStartMin === 'number' ? row.eventStartMin : null;
+  const notifMin = typeof row.notifMin === 'number' ? row.notifMin : null;
+  // Compute dropdown remind me option (ex. 5 mins before event time)
+  const minutesBeforeStartTime = (row.hasNotif === 1 && eventStartMin != null && notifMin != null) ? eventStartMin - notifMin : null;
+
+  // If extensions array exists, map each extension into extensions UI record
+  if (extensionsArr && extensionsArr.length > 0) {
+    // If a flight, extract flight fields
+    if (row.eventType === 1) {
+      const flightFields = ExtensionsToFlight(extensionsArr);
+      console.log('flightFields', flightFields, 'extensionsUI', extensionsUI);
+      if (flightFields) {
+        extensionsUI.depAirportName = stripNulls(flightFields.depAirportName ?? '');
+        extensionsUI.depAirportAddress = stripNulls(flightFields.depAirportAddress ?? '');
+        extensionsUI.arrAirportName = stripNulls(flightFields.arrAirportName ?? '');
+        extensionsUI.arrAirportAddress = stripNulls(flightFields.arrAirportAddress ?? '');
+        extensionsUI.airlineCode = stripNulls(flightFields.airlineCode ?? '');
+        extensionsUI.flightNumber = stripNulls(flightFields.flightNumber ?? '');
+        extensionsUI.airlineName = stripNulls(flightFields.airlineName ?? '');
+        extensionsUI.depAirportIATA = stripNulls(flightFields.depAirportIATA ?? '');
+        extensionsUI.depTime = minutesToHHMM(flightFields.depTimeMin);
+        extensionsUI.boardingTime = minutesToHHMM(flightFields.boardingTimeMin);
+        extensionsUI.boardingGroup = stripNulls(flightFields.boardingGroup ?? '');
+        extensionsUI.gate = stripNulls(flightFields.gate ?? '');
+        extensionsUI.arrAirportIATA = stripNulls(flightFields.arrAirportIATA ?? '');
+        extensionsUI.arrTime = minutesToHHMM(flightFields.arrTimeMin);
+      }
+    }
+    // If a hotel, extract hotel fields
+    else if (row.eventType === 2) {
+      const hotelFields = ExtensionsToHotel(extensionsArr);
+      if (hotelFields) {
+        extensionsUI.name = stripNulls(hotelFields.name ?? '');
+        extensionsUI.address = stripNulls(hotelFields.address ?? '');
+        extensionsUI.checkinTime = minutesToHHMM(hotelFields.checkinTimeMin);
+        extensionsUI.checkoutTime = minutesToHHMM(hotelFields.checkoutTimeMin);
+        extensionsUI.roomNumber = stripNulls(hotelFields.roomNumber ?? '');
+    }
+  }
+}
+
+ // Need to add fields to the DB reminder row specific to the UI card
+ // Sets temporary fields to saved values from DB
+  const UIReminder = {
+    // Copy all fields from DB shared type 
+    ...row,
+    // Give generated their own unique IDs (different from parent series in frontend for UI functionality and prevent duplicate issues)
+    // UI ID is a combination of itemID bigint with the generated reminders original event date
+    itemID: BigInt(`${row.itemID}${row.origEventStartYear}${row.origEventStartDay}${row.origEventStartMin}`),
+    folderID: (typeof row.folderID === 'bigint') ? row.folderID : BigInt(row.folderID),
+    temporaryFolderID: row.folderID == null ? null : ((typeof row.folderID === 'bigint') ? row.folderID : BigInt(row.folderID)),
+    // Generated do not have lastModified field, set to current time for storage
+    lastModified: BigInt(Date.now()),
+    // Add on UI specific fields
+    temporaryTitle: row.title ?? '',
+    extension: extensionsUI,
+    // Normal reminders have no recurrence type
+    originalRecurrenceType: null,
+    temporaryEventStartTime: startStr,
+    temporaryEventEndTime: endStr,
+    temporaryEventEndDay: normalizeDatePickerToCalendar(endDateString) ?? dateString, // Default end day is same as start day (not multi-day)
+    temporaryEventEndDateEnabled: false, // Generated are not multi-day (as series doesn't support it fully)
+    temporaryNotificationTime: minutesBeforeStartTime,
+    temporaryLastModified: '',
+    date: normalizeDatePickerToCalendar(dateString) ?? dateString,
+    titleMessageError: '',
+    folderMessageError: '',
+    timeMessageError: '',
+    isSaved: true,
+    isEditing: false,
+    isSelected: false,
+    isRecurring: false,
+    isConverting: false,
+    isGenerated: true,
+    // Generated itemIDs are the parent series ID, store it to link back to parent series
+    linkedParentSeriesID: (typeof row.itemID === 'bigint') ? row.itemID : BigInt(row.itemID),
+    expanded: true
+  } as UIReminder;
+
+  // If true, update (if existing) or insert (if not) UI reminder into global reminders array
+  if (upsert) {
+    // Compute index for a reminder for card display, use itemID as unique index
+    // Look for existing reminder in reminders array that matches the itemID of the converted reminder
+    const index = reminders.value.findIndex(reminder => String(reminder.itemID) === String(UIReminder.itemID));
+    if (index >= 0) {
+    // If found, replace preexisting reminder in array with new UI object
+    reminders.value[index] = UIReminder;
+  } else {
+    // If not found, add new UI object reminder to the array
+    reminders.value.push(UIReminder);
+  }
+}
+  return UIReminder;
+}
+
 
 
 // Map a DB recurring reminder row into the UI reminder shape needed for card display
@@ -2309,6 +2551,8 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     recurrence: recurrence,
     isRecurring: true,
     isConverting: false,
+    isGenerated: false,
+    linkedParentSeriesID: null,
     expanded: true
   } as UIReminder;
 
@@ -2438,6 +2682,8 @@ onMounted(async () => {
   await loadRemindersForCalendarDate(selectedDate.value);
   // Load reminders for the visible month for calendar events
   await loadRemindersForMonth(selectedDate.value);
+  // Load generated reminders for visible and next month
+  await loadGeneratedReminders(selectedDate.value);
   // Since sync initiates on startup, set cloud toggle to on
   isCloudOn.value = true;
   // Start initial sync on app load
@@ -2715,6 +2961,9 @@ async function saveDailyReminder(reminder: UIReminder, extensionsToSend: Extensi
       mapDBSeriesToUIRecurringReminder(row, 'daily', true);
     }
 
+    // Reload generated reminders after new series creation to immediately show new items
+    await loadGeneratedReminders(selectedDate.value);
+
     // Load folders after creation
     folders.value = mapDBToUIFolder(await readAllFolders());
     reminder.timeMessageError = '';
@@ -2734,6 +2983,9 @@ async function saveDailyReminder(reminder: UIReminder, extensionsToSend: Extensi
         mapDBSeriesToUIRecurringReminder(row, 'daily', true);
       }
 
+     // Reload generated reminders after new series update to immediately show updated items
+     await loadGeneratedReminders(selectedDate.value);
+
       folders.value = mapDBToUIFolder(await readAllFolders());
       reminder.timeMessageError = '';
       return true;
@@ -2751,6 +3003,9 @@ async function saveDailyReminder(reminder: UIReminder, extensionsToSend: Extensi
 
       // Remove old normal reminder from UI
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+
+      // Reload generated reminders after new series creation to immediately show new items
+      await loadGeneratedReminders(selectedDate.value);
 
       folders.value = mapDBToUIFolder(await readAllFolders());
       await loadRemindersForCalendarDate(selectedDate.value);
@@ -2863,6 +3118,9 @@ async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extens
       mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
     }
 
+    // Reload generated reminders after new series creation to immediately show new items
+    await loadGeneratedReminders(selectedDate.value);
+
     // Load folders after creation
     folders.value = mapDBToUIFolder(await readAllFolders());
     reminder.timeMessageError = '';
@@ -2882,6 +3140,9 @@ async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extens
         mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
       }
 
+      // Reload generated reminders after new series update to immediately show updated items
+      await loadGeneratedReminders(selectedDate.value);
+
       folders.value = mapDBToUIFolder(await readAllFolders());
       reminder.timeMessageError = '';
       return true;
@@ -2899,6 +3160,9 @@ async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extens
 
       // Remove old normal reminder from UI
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+
+      // Reload generated reminders after new series creation to immediately show new items
+      await loadGeneratedReminders(selectedDate.value);
 
       folders.value = mapDBToUIFolder(await readAllFolders());
       await loadRemindersForCalendarDate(selectedDate.value);
@@ -3005,6 +3269,9 @@ async function saveMonthlyReminder(reminder: UIReminder, extensionsToSend: Exten
       mapDBSeriesToUIRecurringReminder(row, 'monthly', true);
     }
 
+    // Reload generated reminders after new series update to immediately show updated items
+    await loadGeneratedReminders(selectedDate.value);
+
     folders.value = mapDBToUIFolder(await readAllFolders());
     reminder.timeMessageError = '';
     return true;
@@ -3023,6 +3290,9 @@ async function saveMonthlyReminder(reminder: UIReminder, extensionsToSend: Exten
       if (row) {
         mapDBSeriesToUIRecurringReminder(row, 'monthly', true);
       }
+
+      // Reload generated reminders after new series creation to immediately show new items
+      await loadGeneratedReminders(selectedDate.value);
 
       folders.value = mapDBToUIFolder(await readAllFolders());
       reminder.timeMessageError = '';
@@ -3044,6 +3314,9 @@ async function saveMonthlyReminder(reminder: UIReminder, extensionsToSend: Exten
 
       // Remove old normal reminder from UI list
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+
+      // Reload generated reminders after new series creation to immediately show new items
+      await loadGeneratedReminders(selectedDate.value);
       // Map recurring reminder to UI format
       folders.value = mapDBToUIFolder(await readAllFolders());
       await loadRemindersForCalendarDate(selectedDate.value);
@@ -3134,6 +3407,9 @@ async function saveYearlyReminder(reminder: UIReminder, extensionsToSend: Extens
       mapDBSeriesToUIRecurringReminder(row, 'yearly', true);
     }
 
+     // Reload generated reminders after new series creation to immediately show new items
+     await loadGeneratedReminders(selectedDate.value);
+
     folders.value = mapDBToUIFolder(await readAllFolders());
     reminder.timeMessageError = '';
     return true;
@@ -3150,6 +3426,8 @@ async function saveYearlyReminder(reminder: UIReminder, extensionsToSend: Extens
         mapDBSeriesToUIRecurringReminder(row, 'yearly', true);
       }
 
+      // Reload generated reminders after updated series creation to immediately show updated items
+      await loadGeneratedReminders(selectedDate.value);
       folders.value = mapDBToUIFolder(await readAllFolders());
       reminder.timeMessageError = '';
       return true;
@@ -3166,6 +3444,9 @@ async function saveYearlyReminder(reminder: UIReminder, extensionsToSend: Extens
 
       // Remove old normal reminder from UI list
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+
+      // Reload generated reminders after new series creation to immediately show new items
+      await loadGeneratedReminders(selectedDate.value);
       // Map recurring reminder to UI format
       folders.value = mapDBToUIFolder(await readAllFolders());
       await loadRemindersForCalendarDate(selectedDate.value);
@@ -3455,12 +3736,17 @@ async function deleteRecurringReminderSeries(reminder: UIReminder) {
     // Deleting a series automatically deletes all its generated reminders 
     if (reminder.recurrence.type === 'daily') {
      await deleteItem(reminder.itemID, 21);
+     // Reload generated reminders after new series deletion to immediately show items gone
+     await loadGeneratedReminders(selectedDate.value);
    } else if (reminder.recurrence.type === 'weekly') {
      await deleteItem(reminder.itemID, 22);
+     await loadGeneratedReminders(selectedDate.value);
    } else if (reminder.recurrence.type === 'monthly') {
      await deleteItem(reminder.itemID, 23);
+     await loadGeneratedReminders(selectedDate.value);
    } else if (reminder.recurrence.type === 'yearly') {
      await deleteItem(reminder.itemID, 24);
+     await loadGeneratedReminders(selectedDate.value);
    } else {
     // Not a valid recurrence type
      return;
@@ -3746,6 +4032,7 @@ const filteredReminders = computed(() => {
 watch(selectedDate, async (newDate) => {
   // Load reminders for newly selected calendar date
   await loadRemindersForCalendarDate(newDate);
+  await loadGeneratedReminders(newDate);
 });
 
 // Create events on calendar from reminders
@@ -3846,10 +4133,12 @@ function onNext() {
 async function onMoved(data: Timestamp) {
   console.log('qcalendar onMoved payload:', data);
   await loadRemindersForMonth(selectedDate.value);
+  await loadGeneratedReminders(selectedDate.value);
 }
 async function onChange(data: Timestamp) {
   console.log('qcalendar onChange payload:', data);
   await loadRemindersForMonth(selectedDate.value);
+  await loadGeneratedReminders(selectedDate.value);
 }
 
 function onClickDate(data: Timestamp) {

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-17
+ * Updated: 2025-11-19
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -142,6 +142,7 @@
                   placeholder="Folder name"
                   style="min-width: 160px;"
                   maxlength="24"
+                  autofocus
                 />
               </template>
               <template v-else-if="getReminder(node.id) && getReminder(node.id)!.isEditing">
@@ -771,7 +772,7 @@ import { ref, computed, watch, onMounted } from 'vue';
 import type { UINote, UIReminder, UIFolder } from '../types/ui-types';
 import type { Reminder, DailyReminder, WeeklyReminder, MonthlyReminder, YearlyReminder, Note, Folder, Extension } from '../../src-electron/types/shared-types';
 import {createNote, createReminder, createDailyReminder, createWeeklyReminder, createMonthlyReminder, createYearlyReminder, createOrUpdateOverride, createFolder, createRootFolder,
-  readNote, readNotesInRange, readReminder, readDailyReminder, readWeeklyReminder, readMonthlyReminder, readYearlyReminder, readRemindersInRange, readDailyRemindersInRange, readAllFolders, 
+  readNote, readNotesInRange, readReminder, readDailyReminder, readWeeklyReminder, readMonthlyReminder, readYearlyReminder, readRemindersInRange, readDailyRemindersInRange, readWeeklyRemindersInRange, readMonthlyRemindersInRange, readYearlyRemindersInRange, readGeneratedRemindersInRange, readAllFolders, 
   updateNote, updateReminder, updateDailyReminder, updateWeeklyReminder, updateMonthlyReminder, updateYearlyReminder, updateFolder, 
   deleteItem, deleteFolder} from '../utils/local-db';
 import { FieldsToFlight, FieldsToHotel, FlightToExtensions, HotelToExtensions, ExtensionsToFlight, ExtensionsToHotel } from '../utils/eventtypes';
@@ -1105,6 +1106,8 @@ async function onToggleCloudSync() {
 function onToggleRecurrenceType(item: UIReminder, enabled: boolean) {
   // isRecurring property uses checkbox value from user
   item.isRecurring = enabled;
+  // Clear time errors when toggling recurrence types
+  item.timeMessageError = '';
   // If checkbox is enabled, initialize a default recurrence
   if (enabled) {
     item.recurrence = { 
@@ -1116,9 +1119,15 @@ function onToggleRecurrenceType(item: UIReminder, enabled: boolean) {
     everyNDays: 1,
     seriesEndDate: '' 
   }};
+  // Make sure normal saved reminder is still visible in middle list while changing it to recurring
+  if (item.isSaved) {
+    item.isConverting = true;
+  }
   } else {
     // If disabled, clear recurrence type
     item.recurrence = null;
+    // Checkbox is disabled, reminder isnt becoming recurring
+    item.isConverting = false;
   }
 }
 
@@ -1296,17 +1305,27 @@ function renameTreeNode() {
 }
 
 // On escape when editing, cancel rename and revert back to original name
+// If escape on a draft (not saved, remove it entirely)
 function cancelRename(item: UIReminder | UINote | UIFolder) {
   if (!item) return;
 
   // Distinguish between folder and reminder/note by checking for unique property
   // Rename a folder
   if ('temporaryFolderName' in item) {
-    item.isEditing = false;
-    item.temporaryFolderName = item.folderName;
-    item.folderNameError = '';
-    return;
-  } 
+    // Folder is a draft, remove from UI
+    if (!item.isSaved) {
+      folders.value = folders.value.filter(f => String(f.folderID) !== String(item.folderID));
+      // Clear tree node selection
+      selectedFolderID.value = null;
+      }
+      else {
+        item.isEditing = false;
+      item.temporaryFolderName = item.folderName;
+      item.folderNameError = '';
+      }
+      return;
+    }
+   
   // Rename a reminder
   else if ('temporaryEventStartTime' in item) {
     item.isEditing = false;
@@ -1344,7 +1363,7 @@ function addReminder() {
   // create a UI-only draft reminder with a temporary negative bigint ID
   const tempID = tempIDCounter--;
   // Folder to save reminder in is either root by default if nothing is selected, otherwise selected folder in tree
-  const folderID = selectedFolderID.value ?? 0n;
+  const folderID = normalizeFolderID(selectedFolderID.value, notes.value, reminders.value, folders.value) ?? 0n;
 
   const draft: UIReminder = {
     itemID: tempID,
@@ -1369,7 +1388,8 @@ function addReminder() {
     isSelected: false,
     expanded: true,
     temporaryEventEndDateEnabled: false,
-    isRecurring: false
+    isRecurring: false,
+    isConverting: false
   } as UIReminder;
 
   // Add draft reminder to reminders array for UI rendering
@@ -1514,7 +1534,7 @@ function addNote() {
   // create a UI-only draft note with a temporary negative bigint ID
   const tempID = tempIDCounter--;
    // Folder to save note in is either root by default if nothing is selected, otherwise selected folder in tree
-  const folderID = selectedFolderID.value ?? 0n;
+  const folderID = normalizeFolderID(selectedFolderID.value, notes.value, reminders.value, folders.value) ?? 0n;
 
    const draft: UINote = {
     itemID: tempID,
@@ -1688,6 +1708,8 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
     // Add on UI specific fields
     temporaryTitle: row.title ?? '',
     extension: extensionsUI,
+    // Normal reminders have no recurrence type
+    originalRecurrenceType: null,
     temporaryEventStartTime: startStr,
     temporaryEventEndTime: endStr,
     temporaryEventEndDay: normalizeDatePickerToCalendar(endDateString) ?? dateString, // Default end day is same as start day (not multi-day)
@@ -1702,6 +1724,7 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
     isEditing: false,
     isSelected: false,
     isRecurring: false,
+    isConverting: false,
     expanded: true
   } as UIReminder;
 
@@ -1756,6 +1779,12 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
   // Build recurrence object for UI based on recurrence type
   let recurrence: UIReminder['recurrence'] = null;
 
+  // Determine notification offset display dependent on if recurring reminder has notifications
+  const notificationOffset = row.notifOffsetTimeMin;
+  const hasNotification = row.hasNotifs;
+  // If notification flag is set, convert the notificaiton offset to display or null for never
+  const UINotificationOffset = hasNotification ? Math.abs(notificationOffset ?? 0) : null;
+
   if (recurrenceType === 'daily') {
     // If recurrence type is daily, treat DB row as daily reminder schema
     const dailyReminder = row as DailyReminder;
@@ -1764,7 +1793,7 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
       daily: {
         timeOfDayMin: dailyReminder.seriesStartMin,
         eventDurationMin: dailyReminder.eventDurationMin,
-        notifOffsetTimeMin: dailyReminder.notifOffsetTimeMin,
+        notifOffsetTimeMin: UINotificationOffset,
         everyNDays: dailyReminder.everyNDays,
         seriesEndDate: normalizeDatePickerToCalendar(endDateString) ?? endDateString
       }
@@ -1825,14 +1854,15 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     // Add on UI specific fields
     temporaryTitle: row.title ?? '',
     extension: extensionsUI,
-
+    // Get recurrence type from DB row loaded into the UI
+    originalRecurrenceType: recurrence?.type ?? recurrenceType,
     // Event start time, end time, end day, end date are all unique to non-recurring reminders, override these fields for recurring 
     temporaryEventStartTime: '',
     temporaryEventEndTime: '',
     temporaryEventEndDay: '', // No multi-day support for recurring
     temporaryEventEndDateEnabled: false, // No multi-day support for recurring
     // Temp notification time is same as notifOffsetTimeMin for recurring reminders (but positive)
-    temporaryNotificationTime: ('notifOffsetTimeMin' in row) ? Math.abs(row.notifOffsetTimeMin ?? 0) : null,
+    temporaryNotificationTime: UINotificationOffset,
     eventStartYear: row.seriesStartYear,
     eventStartDay: row.seriesStartDay,
     eventStartMin: row.seriesStartMin,
@@ -1854,6 +1884,7 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     isSelected: false,
     recurrence: recurrence,
     isRecurring: true,
+    isConverting: false,
     expanded: true
   } as UIReminder;
 
@@ -2004,7 +2035,7 @@ function addFolder() {
     temporaryFolderName: 'New Folder',
     isSaved: false,
     isEditing: true, // When new draft is added, automatically in editing mode to name it
-    colorCode: -1
+    colorCode: -1,
   } as UIFolder;
 
   
@@ -2161,6 +2192,11 @@ function getRecurrenceEventDuration(recurrenceType: string): number {
 // Function to validate and save recurring reminder when save button is clicked
 // Returns true if successful (passed validation and saved DB entry), false if not
 async function saveRecurringReminder(reminder: UIReminder) {
+   // clear previous errors before re-validating
+   reminder.titleMessageError = '';
+   reminder.folderMessageError = '';
+   reminder.timeMessageError = '';
+
   // Not a recurring reminder
   if (!reminder.recurrence || !reminder.isRecurring) {
     return false;
@@ -2244,6 +2280,7 @@ async function saveRecurringReminder(reminder: UIReminder) {
     const extensions = buildExtensionsForEventType(reminder);
     // Only send an extension if there are fields to send (otherwise undefined so DB doesn't make an extension)
     const extensionsToSend = (extensions && extensions.length > 0) ? extensions : undefined;
+
       // Recurring reminder not saved to DB yet, create it
       if (!reminder.isSaved) {
         const seriesID = await createDailyReminder(reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
@@ -2258,6 +2295,7 @@ async function saveRecurringReminder(reminder: UIReminder) {
         // Map recurring reminder to UI format
         if (row) {
           mapDBSeriesToUIRecurringReminder(row, 'daily', true);
+
         };
 
         // Load folders after creation
@@ -2268,6 +2306,9 @@ async function saveRecurringReminder(reminder: UIReminder) {
 
       // Recurring reminder saved before, update it
       else {
+        const originalRecurrenceType = reminder.originalRecurrenceType;
+         // Original recurrence type exists, so update existing recurring reminder
+        if (originalRecurrenceType) {
         await updateDailyReminder(reminder.itemID, reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
 
         // Fetch the updated recurring reminder from the DB 
@@ -2282,16 +2323,41 @@ async function saveRecurringReminder(reminder: UIReminder) {
         reminder.timeMessageError = '';
         return true;
       }
+      // Original recurrence type is null, reminder is normal, convert it to a series
+      else {
+      // Create new series reminder
+      const seriesID = await createDailyReminder(reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
+      await deleteItem(reminder.itemID, 12);
+      const row = await readDailyReminder(seriesID);
+       // Map recurring reminder to UI format
+        if (row) {
+          mapDBSeriesToUIRecurringReminder(row, 'daily', true);
+        };
+
+        // Remove old normal reminder from UI 
+        reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+
+        folders.value = mapDBToUIFolder(await readAllFolders());
+        await loadRemindersForCalendarDate(selectedDate.value);   
+        await loadRemindersForMonth(selectedDate.value);
+        reminder.timeMessageError = '';
+        return true;
+      }
     }
-    catch (err) {
-      console.error('Error saving recurring reminder.');
-      return false;
-    }
+  } catch (error) {
+    console.error('Error saving recurring reminder:', error);
+    return false;
+}
   }
 }
 
 // Function to save reminder fields when save button is clicked
 async function saveReminder(reminder: UIReminder){
+  // Clear errors before re-validating
+  reminder.titleMessageError = '';
+  reminder.folderMessageError = '';
+  reminder.timeMessageError = '';
+
   // If reminder title (with whitespace removed) is empty, show error message and disable save button
   if (!reminder.temporaryTitle.trim()) {
     reminder.titleMessageError = 'Reminder title cannot be empty.';
@@ -2468,6 +2534,43 @@ try {
   }
   // Reminder is saved, just updating a preexisting reminder
   else {
+    // If the saved reminder belongs to an existing recurring series (switching from recurring to normal and saving)
+    // Convert series into a normal reminder with its UI fields and delete the series
+    // itemID wont be found/match as recurring is in a different table schema, so need to look at original recurrence type to find which table the series is in
+      const originalRecurrenceType = reminder.originalRecurrenceType ?? reminder.recurrence?.type ?? null;
+      let tableID: number | null = null;
+      if (originalRecurrenceType === 'daily') {
+        tableID = 21;
+      } 
+      else if (originalRecurrenceType === 'weekly') {
+        tableID = 22;
+      } 
+      else if (originalRecurrenceType === 'monthly') {
+        tableID = 23;
+      } 
+      else if (originalRecurrenceType === 'yearly') {
+        tableID = 24;
+      }
+      if (reminder.isSaved && !reminder.isRecurring && tableID != null) {
+        // Create the new normal reminder
+          const itemID = await createReminder(reminder.temporaryFolderID, reminder.eventType, eventStartTime, eventEnd, notificationTimestampToSend, hasNotification, reminder.temporaryTitle, extensionsToSend);
+          // Delete the recurring series (also deletes generated reminders)
+          await deleteItem(reminder.itemID, tableID);
+          // Fetch the newly created reminder from the DB 
+          const row = await readReminder(itemID);
+  
+          // Map DB row into UI and update reminders.value array
+          if (row) {
+            mapDBToUIReminder(row, true);
+          }
+
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      await loadRemindersForCalendarDate(selectedDate.value);   
+
+      // Reload calendar month to include newly added reminder
+      await loadRemindersForMonth(selectedDate.value);
+    }
+      // Reminder is a normal reminder, just update it in DB
       await updateReminder(reminder.itemID, reminder.temporaryFolderID, reminder.eventType, eventStartTime, eventEnd, notificationTimestampToSend, hasNotification, reminder.temporaryTitle, extensionsToSend);
       console.log('Reminder updated successfully in DB.');
 
@@ -2600,6 +2703,21 @@ async function deleteTreeNode() {
         return;
     }
 
+    // Check for a draft folder (negative folder ID) 
+    // Look for folder from folders array thats ID matches the negative selected node
+    const folderDraft = folders.value.find(folder => String(folder.folderID) === String(selectedNode));
+    if (folderDraft) {
+      try {
+        // Folder never been saved before (draft), remove from file explorer list
+        if (!folderDraft.isSaved) {
+          folders.value = folders.value.filter(f => String(f.folderID) !== String(folderDraft.folderID))
+        }
+
+      } catch (error) {
+        console.error('Error deleting draft folder:', error);
+      }
+    }
+
   // Tree node has a negative ID, a note or reminder is selected
   if (selectedNode < 0n) {
     const itemID = -selectedNode;
@@ -2684,10 +2802,22 @@ async function cancelReminder(reminder: UIReminder) {
     await loadRemindersForCalendarDate(selectedDate.value);
   // Reminder is saved, revert temporary fields back to saved database values
   } else {
-    const row = await readReminder(reminder.itemID); 
-    if (row) {
-      mapDBToUIReminder(row, true);
-    } 
+      // Reminder is recurring, cancel its fields back to saved DB state
+      const originalRecurrenceType = reminder.originalRecurrenceType ?? reminder.recurrence?.type ?? null;
+      // Recurring reminder is daily, read from daily table and map to UI
+      if (reminder.isRecurring && originalRecurrenceType === 'daily') {
+        const row = await readDailyReminder(reminder.itemID);
+         if (row) {
+          mapDBSeriesToUIRecurringReminder(row, 'daily', true);
+        } 
+      } 
+      // Normal reminder, read from its table and map to UI
+      else {
+        const row = await readReminder(reminder.itemID);
+        if (row) {
+          mapDBToUIReminder(row, true);
+      } 
+    }
   }
 }
 
@@ -2742,28 +2872,8 @@ const filteredReminders = computed(() => {
   // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
   const query = (searchQuery.value ?? '').trim().toLowerCase();
 
-  // By default, middle list only shows normal reminders and recurring drafts
-  const defaultReminderList = reminders.value.filter(reminder => !reminder.isRecurring || !reminder.isSaved);
-
-  /*
-  // Only show normal reminders and recurring drafts in middle list
-  const visibleReminders = reminders.value.filter(reminder => {
-    // Show saved recurring in middle list temporarily only if selected on the file explorer
-    if (reminder.isRecurring && reminder.isSaved) {
-      // Checks for a tree node selection (tree nodes use negative itemID)
-      if (selectedFolderID.value !== null && selectedFolderID.value < 0n) {
-        const selectedNode = -selectedFolderID.value;
-        // Check if the selected tree node ID (converted to positive) matches the reminder itemID
-        if (String(reminder.itemID) === String(selectedNode)) {
-        }
-
-      
-    }
-    return true;
-  });
-  */
-
- // const noRecurringReminders = reminders.value;
+  // By default, middle list only shows normal reminders and recurring drafts (or saved reminders being converted to recurring)
+  const defaultReminderList = reminders.value.filter(reminder => !reminder.isRecurring || !reminder.isSaved || reminder.isConverting);
 
  // No search query, either show recurring reminder if selected on file explorer
  // Or show default list otherwise (normal reminders and recurring drafts)

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -245,6 +245,11 @@
                         Series start: {{ eventDatetoLocaleString(item.date) }}<br>
                         Series end: {{eventDatetoLocaleString(item.recurrence.daily.seriesEndDate)}}<br>
                       </template>
+
+                      <template v-else-if="item.isRecurring && item.recurrence?.weekly">
+                        Series start: {{ eventDatetoLocaleString(item.date) }}<br>
+                        Series end: {{eventDatetoLocaleString(item.recurrence.weekly.seriesEndDate)}}<br>
+                      </template>
                       
                       Last modified: {{ item.temporaryLastModified }}
                     </div>
@@ -302,7 +307,8 @@
               <!-- everyNDays (daily) must not be less than 1 and timeOfDayMin must be between 0 and 1439-->
               <div v-if="item.recurrence">
                    <q-select
-                    v-model="item.recurrence.type"
+                    :model-value="item.recurrence.type"
+                    @update:model-value="val => onRecurrenceTypeChange(item, val)"
                     :options="recurrenceOptions"
                     label="Recurrence Type"
                     emit-value
@@ -352,7 +358,58 @@
                   style="background-color: #f2f2f2; margin-bottom: 10px"
                 />
                 </div>
+                <div v-if="item.recurrence.type === 'weekly' && item.recurrence.weekly" style="margin-bottom:8px;">
+                  <q-input
+                  v-model.number="item.recurrence.weekly.timeOfDayMin"
+                  label="Event Time (in minutes into day)"
+                  :min="0"
+                  :max="1439"
+                  type="number"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-input
+                  v-model.number="item.recurrence.weekly.eventDurationMin"
+                  label="Event Duration (in minutes)"
+                  :min="0"
+                  type="number"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-input
+                  v-model.number="item.recurrence.weekly.everyNWeeks"
+                  label="Frequency (every # weeks)"
+                  type="number"
+                  :min="1"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-select
+                  v-model="item.recurrence.weekly.daysOfWeek"
+                  :options="daysOfWeekOptions"
+                  label="Days of the week:"
+                  multiple
+                  emit-value 
+                  map-options
+                  dense
+                  outlined
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-input
+                  v-model="item.recurrence.weekly.seriesEndDate"
+                  label="Series End Date"
+                  type="date"
+                  :min="item.date"
+                  :max="endDateRangeRecurring(item.date)"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
                 </div>
+              </div>
               <!-- Hide generic reminders temporary event start and end time for event types -->
               <template v-if="item.eventType !== 1 && item.eventType !== 2 && !item.isRecurring">
               <q-input
@@ -869,6 +926,16 @@ const recurrenceOptions = [
   { label: 'Yearly', value: 'yearly' }
   ];
 
+// List of days of the week options
+const daysOfWeekOptions = [
+  { label: 'Sunday', value: 0 },
+  { label: 'Monday', value: 1 },
+  { label: 'Tuesday', value: 2 },
+  { label: 'Wednesday', value: 3 },
+  { label: 'Thursday', value: 4 },
+  { label: 'Friday', value: 5 },
+  { label: 'Saturday', value: 6 }
+];
   // Function to determine which variable to bind to for notification offset
   // Normal reminders use temporaryNotificationTime field, recurring reminders use notifOffsetTimeMin
   function getNotificationOffset(reminder: UIReminder): number | null {
@@ -1164,7 +1231,7 @@ function onToggleRecurrenceType(item: UIReminder, enabled: boolean) {
     daily: {
     timeOfDayMin: 0,
     eventDurationMin: 0,
-    notifOffsetTimeMin: item.temporaryNotificationTime ?? null,
+    notifOffsetTimeMin: null,
     everyNDays: 1,
     seriesEndDate: '' 
   }};
@@ -1179,6 +1246,47 @@ function onToggleRecurrenceType(item: UIReminder, enabled: boolean) {
     item.isConverting = false;
   }
 }
+
+// Function to handle changing recurrence type from dropdown and ensure fields are initialized
+function onRecurrenceTypeChange(reminder: UIReminder, val: string) {
+  // Invalid dropdown type
+  if (val !== 'daily' && val !== 'weekly' && val !== 'monthly' && val !== 'yearly') {
+    return;
+  }
+
+   // Ensure recurrence object exists
+  if (!reminder.recurrence) {
+    reminder.recurrence = { type: val } as UIReminder['recurrence'];
+  }
+
+  // Recurrence exists (not null)
+  const recurrence = reminder.recurrence!;
+
+   // Update the type
+  recurrence.type = val;
+
+  // Create matching recurrence object with defaults (daily, weekly, monthly or yearly) according to the selected type if it doesn't exist yet
+  // If it already exists, those fields will just be rendered
+  if (val === 'daily' && !recurrence.daily) {
+    recurrence.daily = { 
+    timeOfDayMin: 0,
+    eventDurationMin: 0,
+    notifOffsetTimeMin: null,
+    everyNDays: 1,
+    seriesEndDate: '' 
+  }}
+
+else if (val === 'weekly' && !recurrence.weekly) {
+  recurrence.weekly = { 
+    timeOfDayMin: 0,
+    eventDurationMin: 0,
+    notifOffsetTimeMin: null,
+    daysOfWeek: [], // all days false by default
+    everyNWeeks: 1,
+    seriesEndDate: '' 
+  }}
+}
+
 
 // Change icon depending on cloud sync status
 const cloudIcon = computed(() => {
@@ -1569,9 +1677,14 @@ async function loadRecurringSeries() {
   const endRange = convertTimeAndDateToTimestamp(`${endYear}-12-31`, '23:59');
   try {
     const rows = await readDailyRemindersInRange(startRange, endRange);
-    for (const recurringReminder of rows) {
-      mapDBSeriesToUIRecurringReminder(recurringReminder, 'daily', true);
+    for (const recurringDailyReminder of rows) {
+      mapDBSeriesToUIRecurringReminder(recurringDailyReminder, 'daily', true);
     }
+     // weekly
+    const weeklyRows = await readWeeklyRemindersInRange(startRange, endRange);
+    for (const recurringWeeklyReminder of weeklyRows) {
+      mapDBSeriesToUIRecurringReminder(recurringWeeklyReminder, 'weekly', true);
+    } 
   } catch (error) {
     console.error('Error loading recurring series:', error);
   }
@@ -1849,11 +1962,38 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     };
   }
 
+  else if (recurrenceType === 'weekly') {
+    // If recurrence type is weekly, treat DB row as weekly reminder schema
+    const weeklyReminder = row as WeeklyReminder;
+
+    // Extract daysOfWeek array back from DB stored 7-char string to display in dropdown
+    const daysOfWeekArray: number[] = [];
+        // Fill empty array by iterating over each character in the string
+        // If the character at the index is '1', that day is selected, push its index
+        for (let i = 0; i < 7; i++) {
+          if (weeklyReminder.daysOfWeek.charAt(i) === '1') {
+            daysOfWeekArray.push(i);
+          }
+        }
+
+    recurrence = {
+      type: 'weekly',
+      weekly: {
+        timeOfDayMin: weeklyReminder.seriesStartMin,
+        eventDurationMin: weeklyReminder.eventDurationMin,
+        notifOffsetTimeMin: UINotificationOffset,
+        everyNWeeks: weeklyReminder.everyNWeeks,
+        daysOfWeek: daysOfWeekArray,
+        seriesEndDate: normalizeDatePickerToCalendar(endDateString) ?? endDateString
+      }
+    };
+  }
+
   // UI reminder extension fields as a record, these are the actual values taken from frontend input fields 
   const extensionsUI = {} as Record<string, string | number | null | undefined>;
 
   // DB reminder row with extensions
-  const extensionsArr = (row as DailyReminder & { extensions?: Extension[] }).extensions;
+  const extensionsArr = (row as DailyReminder | WeeklyReminder & { extensions?: Extension[] }).extensions;
 
   // If extensions array exists, map each extension into extensions UI record
   if (extensionsArr && extensionsArr.length > 0) {
@@ -2201,77 +2341,98 @@ async function saveNote(note: UINote){
   }
 }
 
-// Function to validate and save recurring reminder when save button is clicked
+// General function to validate and save recurring reminder when save button is clicked
+// Calls other functions to save dependent on their type
 // Returns true if successful (passed validation and saved DB entry), false if not
 async function saveRecurringReminder(reminder: UIReminder) {
-   // clear previous errors before re-validating
-   reminder.titleMessageError = '';
-   reminder.folderMessageError = '';
-   reminder.timeMessageError = '';
+  // Clear previous errors before re-validating
+  reminder.titleMessageError = '';
+  reminder.folderMessageError = '';
+  reminder.timeMessageError = '';
 
   // Not a recurring reminder
   if (!reminder.recurrence || !reminder.isRecurring) {
     return false;
   }
 
-  // Recurrence exists, validate daily fields
+  // Build event type extensions from UI fields
+  const extensions = buildExtensionsForEventType(reminder);
+  // Only send an extension if there are fields to send (otherwise undefined so DB doesn't make an extension)
+  const extensionsToSend = (extensions && extensions.length > 0) ? extensions : undefined;
+
+  // Validaiton common to all recurrence types
+  // Make sure recurring reminder is saved in preexisting folder
+  if (reminder.temporaryFolderID == null || !folders.value.some(folder => String(folder.folderID) === String(reminder.temporaryFolderID))) {
+    reminder.folderMessageError = 'Reminder must be in a existing folder.';
+    return false;
+  }
+
+  // eventType must be integer value
+  if (!Number.isInteger(reminder.eventType)) {
+    reminder.titleMessageError = 'Invalid event type selected.';
+    return false;
+  }
+
+  // Depending on recurrence type, call its save function (specific validation)
   if (reminder.recurrence.type === 'daily') {
-    if (!reminder.recurrence.daily) {
-      reminder.timeMessageError = 'Daily recurrence settings are missing.';
-      return false;
-    }
+    return await saveDailyReminder(reminder, extensionsToSend);
+  } else if (reminder.recurrence.type === 'weekly') {
+    return await saveWeeklyReminder(reminder, extensionsToSend);
+  }
+  
+  // If no matching type, return false
+  return false;
+}
 
-   const everyNDays = Number(reminder.recurrence.daily.everyNDays);
-   const timeOfDayMin = Number(reminder.recurrence.daily.timeOfDayMin);
-   const eventDurationMin = Number(reminder.recurrence.daily.eventDurationMin);
-    
-     // everyNDays must be not be less than 1
-    if (!Number.isInteger(everyNDays) || everyNDays < 1) {
-      reminder.timeMessageError = 'Recurrence interval must be greater than 1.';
-      return false;
-    }
+// Function to validate and save daily recurring reminders
+async function saveDailyReminder(reminder: UIReminder, extensionsToSend: Extension[] | undefined): Promise<boolean> {
+  if (!reminder.recurrence?.daily) {
+    reminder.timeMessageError = 'Daily recurrence settings are missing.';
+    return false;
+  }
 
-    // timeOfDayMin must be between 0 and 1439 (start and end of day)
-    if (!Number.isInteger(timeOfDayMin) || timeOfDayMin < 0 || timeOfDayMin > 1439) {
-      reminder.timeMessageError = 'Event time must be within the start and end of the day (0 to 1439).';
-      return false;
-    }
+  const startTime = normalizeDatePickerToCalendar(reminder.date) ?? reminder.date;
+  const endTime = normalizeDatePickerToCalendar(reminder.recurrence.daily.seriesEndDate) ?? reminder.recurrence.daily.seriesEndDate;
+  const seriesStartTime = convertTimeAndDateToTimestamp(startTime, '00:00');
+  const seriesEndTime = convertTimeAndDateToTimestamp(endTime, '23:59');
 
-    // Event duration must be positive (zero for instant event)
-    if (!Number.isInteger(eventDurationMin) || eventDurationMin < 0) {
-      reminder.timeMessageError = 'Event duration must be positive (0 for instant events).';
-      return false;
-    }
-
-    // Event duration cannot be more than a day
-    if (eventDurationMin > 1440) {
-      reminder.timeMessageError = 'Event duration cannot be more than a day.';
-      return false;
-    }
-
-    // Convert notification offset to negative for recurring reminders (used in generation)
-    const recurringNotifOffset = reminder.recurrence.daily.notifOffsetTimeMin == null ? 0 : -Math.abs(reminder.recurrence.daily.notifOffsetTimeMin); 
-    // If a notification option (remind me) is not never, series has notifications
-    const hasNotification = reminder.recurrence.daily.notifOffsetTimeMin != null;
-
-    const startTime = normalizeDatePickerToCalendar(reminder.date) ?? reminder.date;
-    const endTime = normalizeDatePickerToCalendar(reminder.recurrence.daily.seriesEndDate) ?? reminder.recurrence.daily.seriesEndDate;
-    const seriesStartTime = convertTimeAndDateToTimestamp(startTime, '00:00');
-    const seriesEndTime = convertTimeAndDateToTimestamp(endTime, '23:59');
+  // Compare exact moment in time if series start time is before series end time, if not, error
+  const startEpoch = timeStamptoEpoch(seriesStartTime);
+  const endEpoch = timeStamptoEpoch(seriesEndTime);
+  if (endEpoch < startEpoch) {
+    reminder.timeMessageError = 'Start time must be before end time.';
+    return false;
+  }
 
   // End day must be provided
-    if (!reminder.recurrence.daily.seriesEndDate) {
-      reminder.timeMessageError = 'Please select a valid event end date for series.';
-      return false;
-    }
+  if (!reminder.recurrence.daily.seriesEndDate) {
+    reminder.timeMessageError = 'Please select a valid event end date for series.';
+    return false;
+  }
 
-    // Compare exact moment in time if series start time is before series end time, if not, error
-    const startEpoch = timeStamptoEpoch(seriesStartTime);
-    const endEpoch = timeStamptoEpoch(seriesEndTime);
-    if (endEpoch < startEpoch) {
-      reminder.timeMessageError = 'Start time must be before end time.';
-      return false;
-    }
+  // timeOfDayMin must be between 0 and 1439 (start and end of day)
+  if (!Number.isInteger(reminder.recurrence.daily.timeOfDayMin) || reminder.recurrence.daily.timeOfDayMin < 0 || reminder.recurrence.daily.timeOfDayMin > 1439) {
+    reminder.timeMessageError = 'Event time must be within the start and end of the day (0 to 1439).';
+    return false;
+  }
+
+  // Event duration must be positive (zero for instant event)
+  if (!Number.isInteger(reminder.recurrence.daily.eventDurationMin) || reminder.recurrence.daily.eventDurationMin < 0) {
+    reminder.timeMessageError = 'Event duration must be positive (0 for instant events).';
+    return false;
+  }
+
+  // Event duration cannot be more than a day
+  if (reminder.recurrence.daily.eventDurationMin > 1440) {
+    reminder.timeMessageError = 'Event duration cannot be more than a day.';
+    return false;
+  }
+
+  // everyNDays must not be less than 1
+  if (!Number.isInteger(reminder.recurrence.daily.everyNDays) || reminder.recurrence.daily.everyNDays < 1) {
+    reminder.timeMessageError = 'Recurrence interval must be greater than 1.';
+    return false;
+  }
 
   // Check that frequency (everyNDays) fits in the series range
   // Prevents recurring series that make no generated reminders (ex. series range is 2 days but frequency is every 3 days)
@@ -2285,93 +2446,224 @@ async function saveRecurringReminder(reminder: UIReminder) {
     return false;
   }
 
-    // Make sure recurring reminder is saved in preexisting folder
-  if (reminder.temporaryFolderID == null || !folders.value.some(folder => String(folder.folderID) === String(reminder.temporaryFolderID))) {
-    reminder.folderMessageError = 'Reminder must be in a existing folder.';
-    return false;
-  }
+  // Assign local variables for DB saving
+  const timeOfDayMin = reminder.recurrence.daily.timeOfDayMin;
+  const eventDurationMin = reminder.recurrence.daily.eventDurationMin;
+  // As long as its not 'never' (null), notification is set
+  const recurringNotifOffset = reminder.recurrence.daily.notifOffsetTimeMin == null ? 0 : -Math.abs(reminder.recurrence.daily.notifOffsetTimeMin);
+  const hasNotification = reminder.recurrence.daily.notifOffsetTimeMin != null;
+  const everyNDays = reminder.recurrence.daily.everyNDays;
+  // folderID already checked in saveRecurringReminder, cast to non-null bigint folder ID to save
+  const folderID: bigint = reminder.temporaryFolderID!;
 
-   // eventType must be integer value 
-  if (!Number.isInteger(reminder.eventType)) {
-    reminder.titleMessageError = 'Invalid event type selected.';
-    return false;
-  }
+  // Save a daily recurring reminder in DB
+  // Recurring reminder not saved to DB yet, create it
+  if (!reminder.isSaved) {
+    const seriesID = await createDailyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
 
-    // All validation passes
-    try {
-    // Build event type extensions from UI fields
-    const extensions = buildExtensionsForEventType(reminder);
-    // Only send an extension if there are fields to send (otherwise undefined so DB doesn't make an extension)
-    const extensionsToSend = (extensions && extensions.length > 0) ? extensions : undefined;
+    // Make sure draft ID matches DB ID so it gets replaced in UI
+    reminder.itemID = seriesID;
+    reminder.isSaved = true;
 
-      // Recurring reminder not saved to DB yet, create it
-      if (!reminder.isSaved) {
-        const seriesID = await createDailyReminder(reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
+    // Fetch the newly created recurring reminder from the DB
+    const row = await readDailyReminder(seriesID);
 
-        // Make sure draft ID matches DB ID so it gets replaced in UI
-        reminder.itemID = seriesID;
-        reminder.isSaved = true;
+    // Map recurring reminder to UI format
+    if (row) {
+      mapDBSeriesToUIRecurringReminder(row, 'daily', true);
+    }
 
-        // Fetch the newly created recurring reminder from the DB 
-        const row = await readDailyReminder(seriesID);
-        
-        // Map recurring reminder to UI format
-        if (row) {
-          mapDBSeriesToUIRecurringReminder(row, 'daily', true);
+    // Load folders after creation
+    folders.value = mapDBToUIFolder(await readAllFolders());
+    reminder.timeMessageError = '';
+    return true;
+  } else {
+    // Recurring reminder saved before, update it
+    const originalRecurrenceType = reminder.originalRecurrenceType;
+    // Original recurrence type exists, so update existing recurring reminder
+    if (originalRecurrenceType) {
+      await updateDailyReminder(reminder.itemID, folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
 
-        };
+      // Fetch the updated recurring reminder from the DB
+      const row = await readDailyReminder(reminder.itemID);
 
-        // Load folders after creation
-        folders.value = mapDBToUIFolder(await readAllFolders());
-        reminder.timeMessageError = '';
-        return true;
+      // Map recurring reminder to UI format
+      if (row) {
+        mapDBSeriesToUIRecurringReminder(row, 'daily', true);
       }
 
-      // Recurring reminder saved before, update it
-      else {
-        const originalRecurrenceType = reminder.originalRecurrenceType;
-         // Original recurrence type exists, so update existing recurring reminder
-        if (originalRecurrenceType) {
-        await updateDailyReminder(reminder.itemID, reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
-
-        // Fetch the updated recurring reminder from the DB 
-        const row = await readDailyReminder(reminder.itemID);
-
-        // Map recurring reminder to UI format
-        if (row) {
-          mapDBSeriesToUIRecurringReminder(row, 'daily', true);
-        };
-
-        folders.value = mapDBToUIFolder(await readAllFolders());
-        reminder.timeMessageError = '';
-        return true;
-      }
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      reminder.timeMessageError = '';
+      return true;
+    } else {
       // Original recurrence type is null, reminder is normal, convert it to a series
-      else {
       // Create new series reminder
-      const seriesID = await createDailyReminder(reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
+      const seriesID = await createDailyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
       // Delete old normal reminder
       await deleteItem(reminder.itemID, 12);
       const row = await readDailyReminder(seriesID);
-       // Map recurring reminder to UI format
-        if (row) {
-          mapDBSeriesToUIRecurringReminder(row, 'daily', true);
-        };
-
-        // Remove old normal reminder from UI 
-        reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
-
-        folders.value = mapDBToUIFolder(await readAllFolders());
-        await loadRemindersForCalendarDate(selectedDate.value);   
-        await loadRemindersForMonth(selectedDate.value);
-        reminder.timeMessageError = '';
-        return true;
+      // Map recurring reminder to UI format
+      if (row) {
+        mapDBSeriesToUIRecurringReminder(row, 'daily', true);
       }
+
+      // Remove old normal reminder from UI
+      reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      await loadRemindersForCalendarDate(selectedDate.value);
+      await loadRemindersForMonth(selectedDate.value);
+      reminder.timeMessageError = '';
+      return true;
     }
-  } catch (error) {
-    console.error('Error saving recurring reminder:', error);
-    return false;
+  }
 }
+
+// Function to validate and save weekly recurring reminders
+async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extension[] | undefined): Promise<boolean> {
+  if (!reminder.recurrence?.weekly) {
+    reminder.timeMessageError = 'Weekly recurrence settings are missing.';
+    return false;
+  }
+
+  // Set series times (local to this function)
+  const startTime = normalizeDatePickerToCalendar(reminder.date) ?? reminder.date;
+  const endTime = normalizeDatePickerToCalendar(reminder.recurrence.weekly.seriesEndDate) ?? reminder.recurrence.weekly.seriesEndDate;
+  const seriesStartTime = convertTimeAndDateToTimestamp(startTime, '00:00');
+  const seriesEndTime = convertTimeAndDateToTimestamp(endTime, '23:59');
+
+  // Compare exact moment in time if series start time is before series end time, if not, error
+  const startEpoch = timeStamptoEpoch(seriesStartTime);
+  const endEpoch = timeStamptoEpoch(seriesEndTime);
+  if (endEpoch < startEpoch) {
+    reminder.timeMessageError = 'Start time must be before end time.';
+    return false;
+  }
+
+  // End day must be provided
+  if (!reminder.recurrence.weekly.seriesEndDate) {
+    reminder.timeMessageError = 'Please select a valid event end date for series.';
+    return false;
+  }
+
+  // timeOfDayMin must be between 0 and 1439 (start and end of day)
+  if (!Number.isInteger(reminder.recurrence.weekly.timeOfDayMin) || reminder.recurrence.weekly.timeOfDayMin < 0 || reminder.recurrence.weekly.timeOfDayMin > 1439) {
+    reminder.timeMessageError = 'Event time must be within the start and end of the day (0 to 1439).';
+    return false;
+  }
+
+  // Event duration must be positive (zero for instant event)
+  if (!Number.isInteger(reminder.recurrence.weekly.eventDurationMin) || reminder.recurrence.weekly.eventDurationMin < 0) {
+    reminder.timeMessageError = 'Event duration must be positive (0 for instant events).';
+    return false;
+  }
+
+  // Event duration cannot be more than a day
+  if (reminder.recurrence.weekly.eventDurationMin > 1440) {
+    reminder.timeMessageError = 'Event duration cannot be more than a day.';
+    return false;
+  }
+
+  // everyNWeeks must not be less than 1
+  if (!Number.isInteger(reminder.recurrence.weekly.everyNWeeks) || reminder.recurrence.weekly.everyNWeeks < 1) {
+    reminder.timeMessageError = 'Recurrence interval must be greater than 1.';
+    return false;
+  }
+
+  // Convert day of weeks array into backend 7-char string for database storage
+  // Flag '1' for event that day (selected) and '0' for no event that day (not selected)
+  // Days of week array is set from the q-select dropdown menu containing each days index (ex. [0, 2] where 0 = Sunday, 2 = Tuesday were chosen)
+
+  // Initialize 7-char string as a char array with all 0's (no selection)
+  // ['0', '0', '0', '0', '0', '0', '0'] where all days are unselected by default
+  const daysOfWeekString = Array(7).fill('0');
+
+  // Loop through each selected day of the weeks indices
+  reminder.recurrence.weekly.daysOfWeek.forEach((index) => {
+    // Ensure index is in range
+    if (index >= 0 && index < 7) {
+      // For each selected day, set flag to 1
+      daysOfWeekString[index] = '1';
+    }
+  });
+  // Join char array into a single string to store in database
+  const daysOfWeekDatabaseString = daysOfWeekString.join('');
+
+  // Make sure at least one weekday is selected
+  if (reminder.recurrence.weekly.daysOfWeek.length === 0) {
+    reminder.timeMessageError = 'Please select at least one day of the week for the event to occur.';
+    return false;
+  }
+
+  // Assign variables for DB saving
+  const timeOfDayMin = reminder.recurrence.weekly.timeOfDayMin;
+  const eventDurationMin = reminder.recurrence.weekly.eventDurationMin;
+  // Notification is set as long as its not 'never' (null)
+  const recurringNotifOffset = reminder.recurrence.weekly.notifOffsetTimeMin == null ? 0 : -Math.abs(reminder.recurrence.weekly.notifOffsetTimeMin);
+  const hasNotification = reminder.recurrence.weekly.notifOffsetTimeMin != null;
+  const everyNWeeks = reminder.recurrence.weekly.everyNWeeks;
+  // folderID already checked in saveRecurringReminder, cast to non-null bigint folder ID to save
+  const folderID: bigint = reminder.temporaryFolderID!;
+
+
+  // Recurring reminder not saved to DB yet, create it
+  if (!reminder.isSaved) {
+    const seriesID = await createWeeklyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
+    // Make sure draft ID matches DB ID so it gets replaced in UI
+    reminder.itemID = seriesID;
+    reminder.isSaved = true;
+
+    // Fetch the newly created recurring reminder from the DB
+    const row = await readWeeklyReminder(seriesID);
+
+    // Map recurring reminder to UI format
+    if (row) {
+      mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
+    }
+
+    // Load folders after creation
+    folders.value = mapDBToUIFolder(await readAllFolders());
+    reminder.timeMessageError = '';
+    return true;
+  } else {
+    // Recurring reminder saved before, update it
+    const originalRecurrenceType = reminder.originalRecurrenceType;
+    // Original recurrence type exists, so update existing recurring reminder
+    if (originalRecurrenceType) {
+      await updateWeeklyReminder(reminder.itemID, folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
+
+      // Fetch the updated recurring reminder from the DB
+      const row = await readWeeklyReminder(reminder.itemID);
+
+      // Map recurring reminder to UI format
+      if (row) {
+        mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
+      }
+
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      reminder.timeMessageError = '';
+      return true;
+    } else {
+      // Original recurrence type is null, reminder is normal, convert it to a series
+      // Create new series reminder
+      const seriesID = await createWeeklyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNWeeks, daysOfWeekDatabaseString, reminder.temporaryTitle, extensionsToSend);
+      // Delete old normal reminder
+      await deleteItem(reminder.itemID, 12);
+      const row = await readWeeklyReminder(seriesID);
+      // Map recurring reminder to UI format
+      if (row) {
+        mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
+      }
+
+      // Remove old normal reminder from UI
+      reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      await loadRemindersForCalendarDate(selectedDate.value);
+      await loadRemindersForMonth(selectedDate.value);
+      reminder.timeMessageError = '';
+      return true;
+    }
   }
 }
 
@@ -2829,12 +3121,20 @@ async function cancelReminder(reminder: UIReminder) {
       // Reminder is recurring, cancel its fields back to saved DB state
       const originalRecurrenceType = reminder.originalRecurrenceType ?? reminder.recurrence?.type ?? null;
       // Recurring reminder is daily, read from daily table and map to UI
-      if (reminder.isRecurring && originalRecurrenceType === 'daily') {
-        const row = await readDailyReminder(reminder.itemID);
+      if (reminder.isRecurring) {
+        if (originalRecurrenceType === 'daily') {
+         const row = await readDailyReminder(reminder.itemID);
          if (row) {
           mapDBSeriesToUIRecurringReminder(row, 'daily', true);
         } 
-      } 
+      }
+      else if (originalRecurrenceType === 'weekly') {
+        const row = await readWeeklyReminder(reminder.itemID);
+        if (row) {
+          mapDBSeriesToUIRecurringReminder(row, 'weekly', true)
+        }
+      }
+    } 
       // Normal reminder, read from its table and map to UI
       else {
         const row = await readReminder(reminder.itemID);

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-14
+ * Updated: 2025-11-16
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -231,8 +231,20 @@
                       Last modified: {{(item.temporaryLastModified) }}
                   </div>
                 <q-checkbox
+                  v-if="!item.isRecurring"
                   v-model="item.temporaryEventEndDateEnabled"
                   label="Multi‑day"
+                  dense
+                  hide-bottom-space
+                  :color="getEventTypeColor(eventTypes, item.eventType)" 
+                  style="margin-bottom:10px"
+                />
+                <br>
+                <q-checkbox
+                   v-if="!item.temporaryEventEndDateEnabled"
+                  v-model="item.isRecurring"
+                  @update:model-value="val => onToggleRecurrenceType(item, val)"
+                  label="Recurring"
                   dense
                   hide-bottom-space
                   :color="getEventTypeColor(eventTypes, item.eventType)" 
@@ -268,8 +280,51 @@
                 outlined
                 style="background-color: #f2f2f2; margin-bottom: 10px"
               />
+              <!-- everyNDays (daily) must not be less than 1 and timeOfDayMin must be between 0 and 1439-->
+              <div v-if="item.recurrence">
+                   <q-select
+                    v-model="item.recurrence.type"
+                    :options="recurrenceOptions"
+                    label="Recurrence Type"
+                    emit-value
+                    map-options
+                    dense
+                    outlined
+                    style="background-color: #f2f2f2; margin-bottom: 10px"
+                  />
+                  <div v-if="item.recurrence.type === 'daily' && item.recurrence.daily" style="margin-bottom:8px;">
+                  <q-input
+                  v-model="item.recurrence.daily.timeOfDayMin"
+                  label="Event time (in minutes into day)"
+                  :min="0"
+                  :max="1439"
+                  type="number"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-input
+                  v-model="item.recurrence.daily.eventDurationMin"
+                  label="Event duration (in minutes)"
+                  :min="0"
+                  type="number"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-input
+                  v-model="item.recurrence.daily.everyNDays"
+                  label="Frequency (every # days)"
+                  type="number"
+                  :min="1"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                </div>
+                </div>
               <!-- Hide generic reminders temporary event start and end time for event types -->
-              <template v-if="item.eventType !== 1 && item.eventType !== 2">
+              <template v-if="item.eventType !== 1 && item.eventType !== 2 && !item.isRecurring">
               <q-input
                   v-model="item.temporaryEventStartTime"
                   :label="getEventStartLabel(item.eventType)"
@@ -746,6 +801,15 @@ const notificationOptions = [
   { label: '1 hour before', value: 60 },
   { label: '2 hours before', value: 120 }
   ];
+
+// List of recurrence type options 
+const recurrenceOptions = [
+  { label: 'Daily', value: 'daily' },
+  { label: 'Weekly', value: 'weekly' },
+  { label: 'Monthly', value: 'monthly' },
+  { label: 'Yearly', value: 'yearly' }
+  ];
+
 // Array of notes
 const notes = ref<UINote[]>([])
 
@@ -977,6 +1041,26 @@ async function onToggleCloudSync() {
    // Incase of error, reset sync status
   } finally {
     isSyncing.value = false;
+  }
+}
+
+// Since a recurrence is an optional property, function to safely toggle checkbox
+function onToggleRecurrenceType(item: UIReminder, enabled: boolean) {
+  // isRecurring property uses checkbox value from user
+  item.isRecurring = enabled;
+  // If checkbox is enabled, initialize a default recurrence
+  if (enabled) {
+    item.recurrence = { 
+    type: 'daily', 
+    daily: {
+    timeOfDayMin: '',
+    eventDurationMin: 0,
+    notifOffsetTimeMin: null,
+    everyNDays: 1
+  }};
+  } else {
+    // If disabled, clear recurrence type
+    item.recurrence = null;
   }
 }
 
@@ -1212,7 +1296,8 @@ function addReminder() {
     isEditing: false,
     isSelected: false,
     expanded: true,
-    temporaryEventEndDateEnabled: false
+    temporaryEventEndDateEnabled: false,
+    isRecurring: false
   } as UIReminder;
 
   // Add draft reminder to reminders array for UI rendering
@@ -1527,7 +1612,9 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
     isSaved: true,
     isEditing: false,
     isSelected: false,
-    expanded: true,
+    // Set this true elsewhere later
+    isRecurring: false,
+    expanded: true
   } as UIReminder;
 
   // If true, update (if existing) or insert (if not) UI reminder into global reminders array

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-20
+ * Updated: 2025-11-21
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -250,6 +250,11 @@
                         Series start: {{ eventDatetoLocaleString(item.date) }}<br>
                         Series end: {{eventDatetoLocaleString(item.recurrence.weekly.seriesEndDate)}}<br>
                       </template>
+
+                       <template v-else-if="item.isRecurring && item.recurrence?.monthly">
+                        Series start: {{ eventDatetoLocaleString(item.date) }}<br>
+                        Series end: {{eventDatetoLocaleString(item.recurrence.monthly.seriesEndDate)}}<br>
+                      </template>
                       
                       Last modified: {{ item.temporaryLastModified }}
                     </div>
@@ -400,6 +405,72 @@
                 />
                 <q-input
                   v-model="item.recurrence.weekly.seriesEndDate"
+                  label="Series End Date"
+                  type="date"
+                  :min="item.date"
+                  :max="endDateRangeRecurring(item.date)"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                </div>
+                <div v-if="item.recurrence.type === 'monthly' && item.recurrence.monthly" style="margin-bottom:8px;">
+                  <q-input
+                  v-model.number="item.recurrence.monthly.timeOfDayMin"
+                  label="Event Time (in minutes into day)"
+                  :min="0"
+                  :max="1439"
+                  type="number"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-input
+                  v-model.number="item.recurrence.monthly.eventDurationMin"
+                  label="Event Duration (in minutes)"
+                  :min="0"
+                  type="number"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <q-checkbox
+                  v-model="item.recurrence.monthly.lastDayOfMonth"
+                  label="Notify on last day of the month"
+                  dense
+                  hide-bottom-space
+                  style="margin-bottom: 10px"
+                />
+                <!-- Example QDate with QInput component code from here: https://quasar.dev/vue-components/date#with-qinput-->
+                  <q-input 
+                  placeholder="Days of the month"
+                  readonly
+                  :model-value="selectedDayOfMonth"
+                  outlined
+                  dense
+                   style="background-color: #f2f2f2; margin-bottom: 10px"
+                  >
+                  <!-- Normalize the visible date picker to be a static month with 31 days -->
+                    <template v-slot:append>
+                      <q-icon name="event" class="cursor-pointer">
+                        <q-popup-proxy cover transition-show="scale" transition-hide="scale">
+                          <q-date v-model="DaysOfMonthSelection" 
+                          :key="String(item.itemID)"
+                          multiple 
+                          minimal
+                          class="monthly-day-picker"
+                          default-year-month="2024/12"
+                          style="width: 200px;">
+                            <div class="row items-center justify-end">
+                              <q-btn v-close-popup label="Close" color="primary" flat />
+                            </div>
+                          </q-date>
+                        </q-popup-proxy>
+                      </q-icon>
+                    </template>
+                  </q-input>
+                <q-input
+                  v-model="item.recurrence.monthly.seriesEndDate"
                   label="Series End Date"
                   type="date"
                   :min="item.date"
@@ -845,6 +916,32 @@ const settingsTab = ref('cloud');
 const reminders = ref<UIReminder[]>([])
 // Array of reminders by month for calendar
 const monthReminders = ref<UIReminder[]>([])
+// Stores the array of full dates selected in qdate component for monthly recurrence
+const DaysOfMonthSelection = ref<string[]>([]);  
+
+// Extract just the days from the full dates of the DaysOfMonthSelection
+// Use these days to set the daysOfMonth array in the MonthlyReminder recurrence 
+// Computed so that it updates automatically when DaysOfMonthSelection changes
+const selectedDayOfMonth = computed(() => {
+  // If daysOfMonthSelection is missing or empty, show empty string
+  if (!DaysOfMonthSelection.value || DaysOfMonthSelection.value.length === 0) {
+    return '';
+  }
+   const days = DaysOfMonthSelection.value.map(dateString => {
+    // Split each date string ex. "YYYY/MM/DD" in the array by '/' delimiter to get each part
+    const parts = dateString.split('/');
+
+    // Last part is the day component "DD"
+    const dayPart = parts[2] ?? '';
+
+    // Convert the day string "DD" to an integer to get rid of leading zeros like "01" for q-input display
+    return parseInt(dayPart, 10);
+    // Sort the days numerically in ascending order for q-input display
+  }).sort((a, b) => a - b); 
+
+  // Join back the stripped day numbers into a comma-separated string for q-input display
+  return days.join(', ');
+});
 
 // Helper function to determine days user can pick for event end day (from start day to one year later)
 // Hard limits reminders to +1 year from start date for event duration
@@ -1285,6 +1382,16 @@ else if (val === 'weekly' && !recurrence.weekly) {
     everyNWeeks: 1,
     seriesEndDate: '' 
   }}
+
+  else if (val === 'monthly' && !recurrence.monthly) {
+  recurrence.monthly = { 
+    timeOfDayMin: 0,
+    eventDurationMin: 0,
+    notifOffsetTimeMin: null,
+    lastDayOfMonth: false,
+    daysOfMonth: [], // all days false by default
+    seriesEndDate: '' 
+  }}
 }
 
 
@@ -1439,7 +1546,8 @@ function renameTreeNode() {
     if (folder) {
         // Show input box
         folder.isEditing = true;
-        // Set temporary name displayed in tree to written name
+        // Copy DB-saved name to temporary field to visually populate it for editing
+        // The actual editing is bound to the temporaryFolderName field
         folder.temporaryFolderName = folder.folderName;
         selectedFolderID.value = folder.folderID;
     }
@@ -1467,7 +1575,7 @@ function cancelRename(item: UIReminder | UINote | UIFolder) {
   if (!item) return;
 
   // Distinguish between folder and reminder/note by checking for unique property
-  // Rename a folder
+  // Cancel renaming a folder
   if ('temporaryFolderName' in item) {
     // Folder is a draft, remove from UI
     if (!item.isSaved) {
@@ -1476,21 +1584,23 @@ function cancelRename(item: UIReminder | UINote | UIFolder) {
       selectedFolderID.value = null;
       }
       else {
-        item.isEditing = false;
+      // Get rid of input box
+      item.isEditing = false;
+      // Revert temporary name back to original folder name from DB
       item.temporaryFolderName = item.folderName;
       item.folderNameError = '';
       }
       return;
     }
    
-  // Rename a reminder
+  // Cancel renaming a reminder
   else if ('temporaryEventStartTime' in item) {
     item.isEditing = false;
     item.temporaryTitle = item.title ?? '';
     item.titleMessageError = '';
     return;
   }
-  // Rename a note
+  // Cancel renaming a note
   else if ('temporaryText' in item) {
     item.isEditing = false;
     item.temporaryTitle = item.title ?? '';
@@ -1512,12 +1622,12 @@ function selectBreadcrumbItem(folderID : bigint) {
   selectedFolderID.value = folderID;
 }
 
-// temp id generator for UI-only drafts (negative IDs)
-// Negative ID for temp objects from: https://stackoverflow.com/questions/53850790/how-to-work-with-unsaved-entities-even-though-id-attribute-is-needed
+// Temp ID generator for UI-only drafts (negative IDs)
+// Negative ID for temp objects idea from: https://stackoverflow.com/questions/53850790/how-to-work-with-unsaved-entities-even-though-id-attribute-is-needed
 let tempIDCounter = -2n;
 // Function to add a reminder to the list on the specified calendar date
 function addReminder() {
-  // create a UI-only draft reminder with a temporary negative bigint ID
+  // Create a UI-only draft reminder with a temporary negative bigint ID
   const tempID = tempIDCounter--;
   // Folder to save reminder in is either root by default if nothing is selected, otherwise selected folder in tree
   const folderID = normalizeFolderID(selectedFolderID.value, notes.value, reminders.value, folders.value) ?? 0n;
@@ -1676,14 +1786,20 @@ async function loadRecurringSeries() {
   const startRange = convertTimeAndDateToTimestamp(`${startYear}-01-01`, '');
   const endRange = convertTimeAndDateToTimestamp(`${endYear}-12-31`, '23:59');
   try {
+    // Load daily reminders
     const rows = await readDailyRemindersInRange(startRange, endRange);
     for (const recurringDailyReminder of rows) {
       mapDBSeriesToUIRecurringReminder(recurringDailyReminder, 'daily', true);
     }
-     // weekly
+    // Load weekly reminders
     const weeklyRows = await readWeeklyRemindersInRange(startRange, endRange);
     for (const recurringWeeklyReminder of weeklyRows) {
       mapDBSeriesToUIRecurringReminder(recurringWeeklyReminder, 'weekly', true);
+    } 
+    // Load monthly reminders
+    const monthlyRows = await readMonthlyRemindersInRange(startRange, endRange);
+    for (const recurringMonthlyReminder of monthlyRows) {
+      mapDBSeriesToUIRecurringReminder(recurringMonthlyReminder, 'monthly', true);
     } 
   } catch (error) {
     console.error('Error loading recurring series:', error);
@@ -1989,11 +2105,38 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
     };
   }
 
+  else if (recurrenceType === 'monthly') {
+    // If recurrence type is monthly, treat DB row as monthly reminder schema
+    const monthlyReminder = row as MonthlyReminder;
+
+     // Extract daysOfMonth array back from DB stored 31-char string to display in grid
+    const daysOfMonthArray: number[] = [];
+        // Fill empty array by iterating over each character in the string
+        // If the character at the index is '1', that day is selected, push its index
+        for (let i = 0; i < 31; i++) {
+          if (monthlyReminder.daysOfMonth.charAt(i) === '1') {
+            daysOfMonthArray.push(i + 1);
+          }
+        }
+    recurrence = {
+      type: 'monthly',
+      monthly: {
+        timeOfDayMin: monthlyReminder.seriesStartMin,
+        eventDurationMin: monthlyReminder.eventDurationMin,
+        notifOffsetTimeMin: UINotificationOffset,
+        // When DB value exists, convert to boolean 
+        lastDayOfMonth: Boolean(monthlyReminder.lastDayOfMonth),
+        daysOfMonth: daysOfMonthArray,
+        seriesEndDate: normalizeDatePickerToCalendar(endDateString) ?? endDateString
+      }
+    };
+  }
+
   // UI reminder extension fields as a record, these are the actual values taken from frontend input fields 
   const extensionsUI = {} as Record<string, string | number | null | undefined>;
 
   // DB reminder row with extensions
-  const extensionsArr = (row as DailyReminder | WeeklyReminder & { extensions?: Extension[] }).extensions;
+  const extensionsArr = (row as DailyReminder | WeeklyReminder | MonthlyReminder & { extensions?: Extension[] }).extensions;
 
   // If extensions array exists, map each extension into extensions UI record
   if (extensionsArr && extensionsArr.length > 0) {
@@ -2211,7 +2354,7 @@ onMounted(async () => {
 
 // Function to add a folder to the tree
 function addFolder() {
-   // create a UI-only draft folder with a temporary negative bigint ID
+   // Create a UI-only draft folder with a temporary negative bigint ID
   const tempID = tempIDCounter--;
   // Sets parentFolderID of new folder to currently selected folder in file explorer tree. If no folder is selected, add new folder to root (parentFolderID = 0)
   const newParentFolderID = normalizeFolderID(selectedFolderID.value, notes.value, reminders.value, folders.value) ?? 0n;
@@ -2253,7 +2396,7 @@ async function saveFolder(folder: UIFolder){
   const normalizeParentFolderID: bigint = normalizeFolderID(candidateParentID, notes.value, reminders.value, folders.value) ?? 0n;
 
   // Check that parentFolderID exists when creating a folder
-  // Check for a folder with the parent folder ID exists in the folders array (or 0 for root)
+  // Check for a folder where the parent folder ID exists in the folders array (or 0 for root)
   const parentFolderExists = candidateParentID === 0n || folders.value.some(folder => String(folder.folderID) === String(candidateParentID));
 
   if (!parentFolderExists) {
@@ -2378,6 +2521,9 @@ async function saveRecurringReminder(reminder: UIReminder) {
     return await saveDailyReminder(reminder, extensionsToSend);
   } else if (reminder.recurrence.type === 'weekly') {
     return await saveWeeklyReminder(reminder, extensionsToSend);
+  }
+  else if (reminder.recurrence.type === 'monthly') {
+    return await saveMonthlyReminder(reminder, extensionsToSend);
   }
   
   // If no matching type, return false
@@ -2510,6 +2656,151 @@ async function saveDailyReminder(reminder: UIReminder, extensionsToSend: Extensi
       // Remove old normal reminder from UI
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
 
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      await loadRemindersForCalendarDate(selectedDate.value);
+      await loadRemindersForMonth(selectedDate.value);
+      reminder.timeMessageError = '';
+      return true;
+    }
+  }
+}
+
+// Function to validate and save monthly recurring reminders
+async function saveMonthlyReminder(reminder: UIReminder, extensionsToSend: Extension[] | undefined): Promise<boolean> {
+  if (!reminder.recurrence?.monthly) {
+    reminder.timeMessageError = 'Monthly recurrence settings are missing.';
+    return false;
+  }
+
+  const startTime = normalizeDatePickerToCalendar(reminder.date) ?? reminder.date;
+  const endTime = normalizeDatePickerToCalendar(reminder.recurrence.monthly.seriesEndDate) ?? reminder.recurrence.monthly.seriesEndDate;
+  const seriesStartTime = convertTimeAndDateToTimestamp(startTime, '00:00');
+  const seriesEndTime = convertTimeAndDateToTimestamp(endTime, '23:59');
+
+  // Compare exact moment in time if series start time is before series end time, if not, error
+  const startEpoch = timeStamptoEpoch(seriesStartTime);
+  const endEpoch = timeStamptoEpoch(seriesEndTime);
+  if (endEpoch < startEpoch) {
+    reminder.timeMessageError = 'Start time must be before end time.';
+    return false;
+  }
+
+  // End day must be provided
+  if (!reminder.recurrence.monthly.seriesEndDate) {
+    reminder.timeMessageError = 'Please select a valid event end date for series.';
+    return false;
+  }
+
+  // timeOfDayMin must be between 0 and 1439 (start and end of day)
+  if (!Number.isInteger(reminder.recurrence.monthly.timeOfDayMin) || reminder.recurrence.monthly.timeOfDayMin < 0 || reminder.recurrence.monthly.timeOfDayMin > 1439) {
+    reminder.timeMessageError = 'Event time must be within the start and end of the day (0 to 1439).';
+    return false;
+  }
+
+  // Event duration must be positive (zero for instant event)
+  if (!Number.isInteger(reminder.recurrence.monthly.eventDurationMin) || reminder.recurrence.monthly.eventDurationMin < 0) {
+    reminder.timeMessageError = 'Event duration must be positive (0 for instant events).';
+    return false;
+  }
+
+  // Event duration cannot be more than a day
+  if (reminder.recurrence.monthly.eventDurationMin > 1440) {
+    reminder.timeMessageError = 'Event duration cannot be more than a day.';
+    return false;
+  }
+
+  // Extract numeric selected days from full date strings in DaysOfMonthSelection
+  const selectedDaysOfMonth: number[] = (DaysOfMonthSelection.value ?? []).map(dateString => {
+    const parts = dateString.split('/');
+    const dayPart = parts[2] ?? '';
+    return parseInt(dayPart, 10);
+  }).filter(dayNumber => Number.isInteger(dayNumber) && dayNumber >= 1 && dayNumber <= 31);
+
+
+  // Initialize 31-char string as a char array with all 0's (no selection)
+  // ['0', '0', '0', '0', '0', '0', '0'] where all days of the month are unselected by default
+  const daysOfMonthString = Array(31).fill('0');
+
+  // Loop through each selected day of the month
+  selectedDaysOfMonth.forEach((index) => {
+    // Ensure index is in range
+    if (index >= 0 && index <= 31) {
+      // For each selected day, set flag to 1
+      daysOfMonthString[index - 1] = '1';
+    }
+  });
+  // Join each character into a single string to store in database
+  const daysOfMonthDatabaseString = daysOfMonthString.join('');
+
+  // Make sure at least one day of the month is selected
+  if (selectedDaysOfMonth.length === 0) {
+    reminder.timeMessageError = 'Please select at least one day of the month for the event to occur.';
+    return false;
+  }
+
+  // Assign local variables for DB saving
+  const timeOfDayMin = reminder.recurrence.monthly.timeOfDayMin;
+  const eventDurationMin = reminder.recurrence.monthly.eventDurationMin;
+  const recurringNotifOffset = reminder.recurrence.monthly.notifOffsetTimeMin == null ? 0 : -Math.abs(reminder.recurrence.monthly.notifOffsetTimeMin);
+  const hasNotification = reminder.recurrence.monthly.notifOffsetTimeMin != null;
+  const lastDayOfMonth = reminder.recurrence.monthly.lastDayOfMonth;
+  const folderID: bigint = reminder.temporaryFolderID!;
+
+  // Recurring reminder not saved to DB yet, create it
+  if (!reminder.isSaved) {
+    const seriesID = await createMonthlyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, lastDayOfMonth, daysOfMonthDatabaseString, reminder.temporaryTitle, extensionsToSend);
+
+    reminder.itemID = seriesID;
+    reminder.isSaved = true;
+
+    // Fetch the newly created recurring reminder from the DB
+    const row = await readMonthlyReminder(seriesID);
+
+    // Map recurring reminder to UI format
+    if (row) {
+      mapDBSeriesToUIRecurringReminder(row, 'monthly', true);
+    }
+
+    folders.value = mapDBToUIFolder(await readAllFolders());
+    reminder.timeMessageError = '';
+    return true;
+  } else {
+    // Recurring reminder saved before, update it
+    const originalRecurrenceType = reminder.originalRecurrenceType;
+
+    if (originalRecurrenceType) {
+      // Update existing series in DB
+      await updateMonthlyReminder(reminder.itemID, folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, lastDayOfMonth, daysOfMonthDatabaseString, reminder.temporaryTitle, extensionsToSend);
+
+      // Fetch the updated recurring reminder from the DB
+      const row = await readMonthlyReminder(reminder.itemID);
+
+      // Map recurring reminder to UI format
+      if (row) {
+        mapDBSeriesToUIRecurringReminder(row, 'monthly', true);
+      }
+
+      folders.value = mapDBToUIFolder(await readAllFolders());
+      reminder.timeMessageError = '';
+      return true;
+
+    } else {
+      // Original recurrence type is null, reminder is normal, convert it to a series
+      // Create new series reminder
+      const seriesID = await createMonthlyReminder(folderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, lastDayOfMonth, daysOfMonthDatabaseString, reminder.temporaryTitle, extensionsToSend);
+
+      // Delete old normal reminder
+      await deleteItem(reminder.itemID, 12);
+
+      const row = await readMonthlyReminder(seriesID);
+
+      if (row) {
+        mapDBSeriesToUIRecurringReminder(row, 'monthly', true);
+      }
+
+      // Remove old normal reminder from UI list
+      reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+      // Map recurring reminder to UI format
       folders.value = mapDBToUIFolder(await readAllFolders());
       await loadRemindersForCalendarDate(selectedDate.value);
       await loadRemindersForMonth(selectedDate.value);
@@ -3133,6 +3424,11 @@ async function cancelReminder(reminder: UIReminder) {
         if (row) {
           mapDBSeriesToUIRecurringReminder(row, 'weekly', true)
         }
+      } else if (originalRecurrenceType === 'monthly') {
+        const row = await readMonthlyReminder(reminder.itemID);
+        if (row) {
+          mapDBSeriesToUIRecurringReminder(row, 'monthly', true)
+        }
       }
     } 
       // Normal reminder, read from its table and map to UI
@@ -3174,7 +3470,6 @@ watch(selectAll, (selectionVal) => {
     });
   }
 });
-
 
 // template and script source code from slot - day month example
 // https://qcalendar.netlify.app/developing/qcalendar-month

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -226,10 +226,26 @@
                     </div>
               </template>
               <q-card-section>
-                    <div style="padding-bottom:10px">
-                      Event date: {{ eventDatetoLocaleString(item.date) }}<br>
-                      Last modified: {{(item.temporaryLastModified) }}
-                  </div>
+                     <div style="padding-bottom:10px">
+                      <!-- Single-day non-recurring reminder -->
+                      <template v-if="!item.isRecurring && !item.temporaryEventEndDateEnabled">
+                        Event date: {{ eventDatetoLocaleString(item.date) }}<br>
+                      </template>
+                      
+                      <!-- Multi-day non-recurring reminder -->
+                      <template v-else-if="!item.isRecurring && item.temporaryEventEndDateEnabled">
+                        Event start: {{ eventDatetoLocaleString(item.date) }}<br>
+                        Event end: {{ eventDatetoLocaleString(item.temporaryEventEndDay) }}<br>
+                      </template>
+                      
+                      <!-- Recurring reminder -->
+                      <template v-else-if="item.isRecurring && item.recurrence?.daily">
+                        Series start: {{ eventDatetoLocaleString(item.date) }}<br>
+                        Series end: {{eventDatetoLocaleString(item.recurrence.daily.seriesEndDate)}}<br>
+                      </template>
+                      
+                      Last modified: {{ item.temporaryLastModified }}
+                    </div>
                 <q-checkbox
                   v-if="!item.isRecurring"
                   v-model="item.temporaryEventEndDateEnabled"
@@ -295,7 +311,7 @@
                   <div v-if="item.recurrence.type === 'daily' && item.recurrence.daily" style="margin-bottom:8px;">
                   <q-input
                   v-model="item.recurrence.daily.timeOfDayMin"
-                  label="Event time (in minutes into day)"
+                  label="Event Time (in minutes into day)"
                   :min="0"
                   :max="1439"
                   type="number"
@@ -305,7 +321,7 @@
                 />
                 <q-input
                   v-model="item.recurrence.daily.eventDurationMin"
-                  label="Event duration (in minutes)"
+                  label="Event Duration (in minutes)"
                   :min="0"
                   type="number"
                   outlined
@@ -317,6 +333,17 @@
                   label="Frequency (every # days)"
                   type="number"
                   :min="1"
+                  outlined
+                  dense
+                  style="background-color: #f2f2f2; margin-bottom: 10px"
+                />
+                <!--- Limiting series end date to 100 years from now at max -->
+                <q-input
+                  v-model="item.recurrence.daily.seriesEndDate"
+                  label="Series End Date"
+                  type="date"
+                  :min="item.date"
+                  :max="endDateRangeRecurring(item.date)"
                   outlined
                   dense
                   style="background-color: #f2f2f2; margin-bottom: 10px"
@@ -742,7 +769,10 @@ import { convertTimeAndDateToTimestamp, convertNotificationTimestamp, minutesToH
 import { ref, computed, watch, onMounted } from 'vue';
 import type { UINote, UIReminder, UIFolder } from '../types/ui-types';
 import type { Reminder, Note, Folder, Extension } from '../../src-electron/types/shared-types';
-import {createNote, createReminder, createFolder, createRootFolder, readNote, readReminder, readAllFolders, updateNote, updateReminder, updateFolder, deleteItem, deleteFolder, readRemindersInRange, readNotesInRange} from '../utils/local-db';
+import {createNote, createReminder, createDailyReminder, createWeeklyReminder, createMonthlyReminder, createYearlyReminder, createOrUpdateOverride, createFolder, createRootFolder,
+  readNote, readNotesInRange, readReminder, readRemindersInRange, readAllFolders, 
+  updateNote, updateReminder, updateDailyReminder, updateWeeklyReminder, updateMonthlyReminder, updateYearlyReminder, updateFolder, 
+  deleteItem, deleteFolder} from '../utils/local-db';
 import { FieldsToFlight, FieldsToHotel, FlightToExtensions, HotelToExtensions, ExtensionsToFlight, ExtensionsToHotel } from '../utils/eventtypes';
 import { useQuasar } from 'quasar';
 import { useRouter } from 'vue-router';
@@ -765,6 +795,7 @@ function endDateRange(startDate: string): { min: string; max: string } {
   if (!dateString) {
     dateString = normalizeDatePickerToCalendar(String(selectedDate.value ?? '')) || '';
   }
+
   if (dateString) {
     const [yearString, monthString, dayString] = dateString.split('-');
     const year = Number(yearString);
@@ -775,8 +806,7 @@ function endDateRange(startDate: string): { min: string; max: string } {
     sDate.setHours(0, 0, 0, 0);
 
     const endDate = new Date(sDate);
-    // Takes the start date (0 time) and adds 365 
-    // days to it for max end date
+    // Takes the start date (0 time) and adds 365 days to it for max end date
     endDate.setDate(endDate.getDate() + 365);
 
     const startString = `${sDate.getFullYear()}-${String(sDate.getMonth() + 1).padStart(2, '0')}-${String(sDate.getDate()).padStart(2, '0')}`;
@@ -788,6 +818,32 @@ function endDateRange(startDate: string): { min: string; max: string } {
 
   // If input is invalid or empty, return empty strings to satisfy the declared return type
   return { min: '', max: '' };
+}
+
+// Helper function to determine days user can pick for series end day (from start day to 100 years later)
+function endDateRangeRecurring(startDate: string) {
+  let dateString = normalizeDatePickerToCalendar(startDate ?? '') || '';
+  // If provided startDate is empty/invalid, fallback to currently selected calendar date
+  if (!dateString) {
+    dateString = normalizeDatePickerToCalendar(String(selectedDate.value ?? '')) || '';
+  }
+
+  if (dateString) {
+    const [yearString, monthString, dayString] = dateString.split('-');
+    const year = Number(yearString);
+    const month = Number(monthString);
+    const day = Number(dayString);
+    // Create a new start date object from inputted start date with 0 hours, minutes, seconds to compare full day
+    const sDate = new Date(year, month - 1, day);
+    sDate.setHours(0, 0, 0, 0);
+
+    const endDate = new Date(sDate);
+    // Takes the start date (0 time) and add 100 years for end date
+    endDate.setFullYear(endDate.getFullYear() + 100);
+    const endString = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}`;
+
+    return endString;
+  }
 }
 
 // List of notification options for when to be notified for reminder
@@ -1055,8 +1111,9 @@ function onToggleRecurrenceType(item: UIReminder, enabled: boolean) {
     daily: {
     timeOfDayMin: '',
     eventDurationMin: 0,
-    notifOffsetTimeMin: null,
-    everyNDays: 1
+    notifOffsetTimeMin: item.temporaryNotificationTime ?? null,
+    everyNDays: 1,
+    seriesEndDate: '' 
   }};
   } else {
     // If disabled, clear recurrence type
@@ -1879,6 +1936,157 @@ async function saveNote(note: UINote){
   }
 }
 
+// Function to limit event duration by recurrence type to prevent overlaps
+// Ex. Daily reminders cant be more than 1 day, weekly more than a week, etc.
+function getRecurrenceEventDuration(recurrenceType: string): number {
+  switch (recurrenceType) {
+    case 'daily': {
+      // Number of minutes in a day (24 hrs a day * 60 min an hr = 1140 min max)
+      // event duration cannot exceed more than 1 day (24 hours) for a daily recurring reminder
+      return 1140;
+    }
+
+    case 'weekly': {
+      // Number of minutes in a week (7 days * 24 hrs a day * 60 min an hr = 10080 min max)
+      // event duration cannot exceed more than 1 week/7 days for a weekly recurring reminder
+      return 10080;
+    }
+
+    case 'monthly': {
+      // Number of minutes in a month (28 days * 24 hrs a day * 60 min an hr = 40320 min max)
+      // event duration cannot exceed more than 1 month/28 days for a monthly recurring reminder
+      // Using 28 days for safety because using 31 days can be dangerous for a month with less (it will overlap)
+      return 40320;
+    }
+
+    case 'yearly': {
+      // Number of minutes in a year (365 days * 24 hrs a day * 60 min an hr = 525600 min max)
+      // event duration cannot exceed more than 1 year/365 days for yearly recurring reminder
+      // Using 365 days (not 366 for leap) for safety
+      return 525600;
+    }
+
+    // If nothing else matches, use daily (within a day)
+    default: {
+      return 1440;
+    }
+  }
+}
+
+// Function to validate and save recurring reminder when save button is clicked
+// Returns true if successful (passed validation and saved DB entry), false if not
+async function saveRecurringReminder(reminder: UIReminder) {
+  // Not a recurring reminder
+  if (!reminder.recurrence || !reminder.isRecurring) {
+    return false;
+  }
+
+  // Recurrence exists, validate daily fields
+  if (reminder.recurrence.type === 'daily') {
+    if (!reminder.recurrence.daily) {
+      reminder.timeMessageError = 'Daily recurrence settings are missing.';
+      return false;
+    }
+
+   const everyNDays = Number(reminder.recurrence.daily.everyNDays);
+   const timeOfDayMin = Number(reminder.recurrence.daily.timeOfDayMin);
+   const eventDurationMin = Number(reminder.recurrence.daily.eventDurationMin);
+    
+     // everyNDays must be not be less than 1
+    if (!Number.isInteger(everyNDays) || everyNDays < 1) {
+      reminder.timeMessageError = 'Recurrence interval must be greater than 1.';
+      return false;
+    }
+
+    // timeOfDayMin must be between 0 and 1439 (start and end of day)
+    if (!Number.isInteger(timeOfDayMin) || timeOfDayMin < 0 || timeOfDayMin > 1439) {
+      reminder.timeMessageError = 'Event time must be within the start and end of the day (0 to 1439).';
+      return false;
+    }
+
+    // Event duration must be positive (zero for instant event)
+    if (!Number.isInteger(eventDurationMin) || eventDurationMin < 0) {
+      reminder.timeMessageError = 'Event duration must be positive (0 for instant events).';
+      return false;
+    }
+
+    // Daily reminder cannot be more than a day
+    const maxDailyDuration = getRecurrenceEventDuration('daily');
+    if (eventDurationMin > maxDailyDuration) {
+      reminder.timeMessageError = 'Daily reminder cannot last more than a day.';
+      return false;
+    }
+
+    // Convert notification offset to negative for recurring reminders (used in generation)
+    const recurringNotifOffset = reminder.recurrence.daily.notifOffsetTimeMin == null ? 0 : -Math.abs(reminder.recurrence.daily.notifOffsetTimeMin); 
+    // If a notification option (remind me) is not never, series has notifications
+    const hasNotification = reminder.recurrence.daily.notifOffsetTimeMin != null;
+
+    const startTime = normalizeDatePickerToCalendar(reminder.date) ?? reminder.date;
+    const endTime = normalizeDatePickerToCalendar(reminder.recurrence.daily.seriesEndDate) ?? reminder.recurrence.daily.seriesEndDate;
+    const seriesStartTime = convertTimeAndDateToTimestamp(startTime, '00:00');
+    const seriesEndTime = convertTimeAndDateToTimestamp(endTime, '23:59');
+
+  // End day must be provided
+    if (!reminder.recurrence.daily.seriesEndDate) {
+      reminder.timeMessageError = 'Please select a valid event end date for series.';
+      return false;
+    }
+
+    // Compare exact moment in time if series start time is before series end time, if not, error
+    const startEpoch = timeStamptoEpoch(seriesStartTime);
+    const endEpoch = timeStamptoEpoch(seriesEndTime);
+    if (endEpoch < startEpoch) {
+      reminder.timeMessageError = 'Start time must be before end time.';
+      return false;
+    }
+
+    // Make sure recurring reminder is saved in preexisting folder
+  if (reminder.temporaryFolderID == null || !folders.value.some(folder => String(folder.folderID) === String(reminder.temporaryFolderID))) {
+    reminder.folderMessageError = 'Reminder must be in a existing folder.';
+    return false;
+  }
+
+   // eventType must be integer value 
+  if (!Number.isInteger(reminder.eventType)) {
+    reminder.titleMessageError = 'Invalid event type selected.';
+    return false;
+  }
+
+    // All validation passes
+    try {
+    // Build event type extensions from UI fields
+    const extensions = buildExtensionsForEventType(reminder);
+    // Only send an extension if there are fields to send (otherwise undefined so DB doesn't make an extension)
+    const extensionsToSend = (extensions && extensions.length > 0) ? extensions : undefined;
+      // Recurring reminder not saved to DB yet, create it
+      if (!reminder.isSaved) {
+      const seriesID = await createDailyReminder(reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
+
+        // Since recurring is not displayed in list/calendar (not mapped to UI card), update series ID and isSaved
+        reminder.itemID = seriesID;
+        reminder.isSaved = true;
+
+        folders.value = mapDBToUIFolder(await readAllFolders());
+        reminder.timeMessageError = '';
+        return true;
+      }
+      // Recurring reminder saved before, update it
+      else {
+          await updateDailyReminder(reminder.itemID, reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
+          folders.value = mapDBToUIFolder(await readAllFolders());
+          reminder.timeMessageError = '';
+          return true;
+      }
+    }
+    catch (err) {
+      console.error('Error saving recurring reminder.');
+      return false;
+    }
+
+  }
+}
+
 // Function to save reminder fields when save button is clicked
 async function saveReminder(reminder: UIReminder){
   // If reminder title (with whitespace removed) is empty, show error message and disable save button
@@ -1892,16 +2100,30 @@ async function saveReminder(reminder: UIReminder){
     return;
   }
   // eventType must be integer value 
-  if (typeof reminder.eventType !== 'number' || !Number.isInteger(reminder.eventType)) {
+  if (!Number.isInteger(reminder.eventType)) {
     reminder.titleMessageError = 'Invalid event type selected.';
     return;
   }
   // Folder must exist
   // Checks if folder id (temporary folder) matches any existing folder ids in folders array
   if (reminder.temporaryFolderID == null || !folders.value.some(folder => String(folder.folderID) === String(reminder.temporaryFolderID))) {
-    reminder.folderMessageError = 'Reminder must be in a existing folder';
+    reminder.folderMessageError = 'Reminder must be in a existing folder.';
     return;
   }
+
+  // If reminder is recurring, save it separately and return
+  const recurringReminder = await saveRecurringReminder(reminder);
+  // If saveRecurringReminder returned true, the save was successful
+  if (recurringReminder) {
+    return;
+  }
+
+  // If recurring reminder returned false by failing validation, stop
+   if (!recurringReminder && reminder.timeMessageError) {
+   return;
+ }
+
+  // Continue with normal reminder saving
   
   const extension = reminder.extension ?? {};
 
@@ -1917,7 +2139,6 @@ async function saveReminder(reminder: UIReminder){
     const fieldString = String(fieldRawValue).trim();
     return fieldString === '' ? undefined : fieldString;
   };
-
 
   let startTimeStr = '';
   let endTimeStr = '';
@@ -2280,6 +2501,7 @@ const filteredReminders = computed(() => {
   // Normalize search query: remove whitespace and convert to lowercase for case-insensitive matching
   // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
   const query = (searchQuery.value ?? '').trim().toLowerCase();
+
   if (!searchQuery.value) {
     // If no search query, default show reminders for selected calendar date
     return reminders.value.filter(reminder => reminder.date === selectedDate.value);

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-16
+ * Updated: 2025-11-17
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -17,6 +17,7 @@
  * https://github.com/quasarframework/quasar/discussions/11048 for custom q-tree node headers
  * https://stackoverflow.com/questions/48351987/create-javascript-date-object-from-string-yyyy-mm-dd-in-local-timezone for constructing local date objects
  * https://stackoverflow.com/questions/12710905/how-do-i-dynamically-assign-properties-to-an-object-in-typescript for record type and dynamically rendering event type fields
+ * https://github.com/quasarframework/quasar/discussions/12942 for how native input type doesn't cast to number by default
  *
  * This file is a part of OpenOrganizer.
  * This file and all source code within it are governed by the copyright and 
@@ -310,7 +311,7 @@
                   />
                   <div v-if="item.recurrence.type === 'daily' && item.recurrence.daily" style="margin-bottom:8px;">
                   <q-input
-                  v-model="item.recurrence.daily.timeOfDayMin"
+                  v-model.number="item.recurrence.daily.timeOfDayMin"
                   label="Event Time (in minutes into day)"
                   :min="0"
                   :max="1439"
@@ -320,7 +321,7 @@
                   style="background-color: #f2f2f2; margin-bottom: 10px"
                 />
                 <q-input
-                  v-model="item.recurrence.daily.eventDurationMin"
+                  v-model.number="item.recurrence.daily.eventDurationMin"
                   label="Event Duration (in minutes)"
                   :min="0"
                   type="number"
@@ -329,7 +330,7 @@
                   style="background-color: #f2f2f2; margin-bottom: 10px"
                 />
                 <q-input
-                  v-model="item.recurrence.daily.everyNDays"
+                  v-model.number="item.recurrence.daily.everyNDays"
                   label="Frequency (every # days)"
                   type="number"
                   :min="1"
@@ -768,9 +769,9 @@ import { buildBreadcrumbs, normalizeFolderID, buildRootNodes} from '../frontend-
 import { convertTimeAndDateToTimestamp, convertNotificationTimestamp, minutesToHHMM, timeStamptoEpoch, normalizeDatePickerToCalendar, eventDatetoLocaleString } from '../frontend-utils/time';
 import { ref, computed, watch, onMounted } from 'vue';
 import type { UINote, UIReminder, UIFolder } from '../types/ui-types';
-import type { Reminder, Note, Folder, Extension } from '../../src-electron/types/shared-types';
+import type { Reminder, DailyReminder, WeeklyReminder, MonthlyReminder, YearlyReminder, Note, Folder, Extension } from '../../src-electron/types/shared-types';
 import {createNote, createReminder, createDailyReminder, createWeeklyReminder, createMonthlyReminder, createYearlyReminder, createOrUpdateOverride, createFolder, createRootFolder,
-  readNote, readNotesInRange, readReminder, readRemindersInRange, readAllFolders, 
+  readNote, readNotesInRange, readReminder, readDailyReminder, readWeeklyReminder, readMonthlyReminder, readYearlyReminder, readRemindersInRange, readDailyRemindersInRange, readAllFolders, 
   updateNote, updateReminder, updateDailyReminder, updateWeeklyReminder, updateMonthlyReminder, updateYearlyReminder, updateFolder, 
   deleteItem, deleteFolder} from '../utils/local-db';
 import { FieldsToFlight, FieldsToHotel, FlightToExtensions, HotelToExtensions, ExtensionsToFlight, ExtensionsToHotel } from '../utils/eventtypes';
@@ -1109,7 +1110,7 @@ function onToggleRecurrenceType(item: UIReminder, enabled: boolean) {
     item.recurrence = { 
     type: 'daily', 
     daily: {
-    timeOfDayMin: '',
+    timeOfDayMin: 0,
     eventDurationMin: 0,
     notifOffsetTimeMin: item.temporaryNotificationTime ?? null,
     everyNDays: 1,
@@ -1221,15 +1222,29 @@ function handleTreeSelection(newlySelectedNode: bigint | null) {
       const reminder = reminders.value.find(reminder => String(reminder.itemID) === String(itemID));
       // Node is a reminder
       if (reminder) {
-        // Switch to reminder tab
-        tab.value='reminders';
-        // Set date to reminder date on calendar
-        selectedDate.value = reminder.date;
-        // Collapse all other reminders except the selected entry
-        reminders.value.forEach(reminder =>  {reminder.expanded = false; })
-        // Expand the selected reminder card 
-        reminder.expanded = true;
-        return;
+        // Reminder is recurring
+        if (reminder.isRecurring) {
+          tab.value='reminders';
+          // Set date to reminder (series start) date on calendar
+          selectedDate.value = reminder.date;
+          // Collapse all other reminders except the selected entry
+          reminders.value.forEach(reminder => {reminder.expanded = false; })
+          // Expand the selected reminder card 
+          reminder.expanded = true;
+          return;
+        }
+        // Reminder is not recurring
+        else {
+          // Switch to reminder tab
+          tab.value='reminders';
+          // Set date to reminder date on calendar
+          selectedDate.value = reminder.date;
+          // Collapse all other reminders except the selected entry
+          reminders.value.forEach(reminder =>  {reminder.expanded = false; })
+          // Expand the selected reminder card 
+          reminder.expanded = true;
+          return;
+        }
       }
       // Node is a note
       const note = notes.value.find(note => String(note.itemID) === String(itemID));
@@ -1375,7 +1390,7 @@ async function loadRemindersForCalendarDate(dateString: string) {
 
   try {
     // Filter out any reminders already in list for that date to avoid duplicates
-    reminders.value = reminders.value.filter(reminder => reminder.date !== dateString);
+    reminders.value = reminders.value.filter(reminder => reminder.isRecurring || reminder.date !== dateString);
     // Read reminders for currently selected date from local DB
     const rows = await readRemindersInRange(startOfDay, endOfDay);
     // Convert each reminder in range from response to UI reminder format 
@@ -1458,7 +1473,7 @@ async function loadReminders(year?: number) {
   const start = convertTimeAndDateToTimestamp(lastYear.toString() + '-01-01', '');
   const end = convertTimeAndDateToTimestamp(nextYear.toString() + '-12-31', '23:59');
   try {
-    // clear list before reloading
+    // clear list before reloading so it reflects only entries from the DB
     reminders.value = [];
     const rows = await readRemindersInRange(start, end);
     // convert each note in range from response to UI note format
@@ -1472,6 +1487,27 @@ async function loadReminders(year?: number) {
     console.error('Error loading reminders:', error);
   }
 }
+
+// Function to load recurring series from DB into UI
+async function loadRecurringSeries() {
+  // Load recurring series from current year to +/- 10 years
+  // Series may be up to 100 years in future, but loading that many series at once is a performance hit
+  // Only need to load series in usable range
+  const currentYear = new Date().getFullYear();
+  const startYear = currentYear - 10;
+  const endYear = currentYear + 10;
+  const startRange = convertTimeAndDateToTimestamp(`${startYear}-01-01`, '');
+  const endRange = convertTimeAndDateToTimestamp(`${endYear}-12-31`, '23:59');
+  try {
+    const rows = await readDailyRemindersInRange(startRange, endRange);
+    for (const recurringReminder of rows) {
+      mapDBSeriesToUIRecurringReminder(recurringReminder, 'daily', true);
+    }
+  } catch (error) {
+    console.error('Error loading recurring series:', error);
+  }
+}
+
 
 // Function to add a note to the list
 function addNote() {
@@ -1579,8 +1615,6 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
   // Get last modified and convert for display
   const lastModifiedEpoch = Number(row.lastModified);
   const reminderDate = new Date(lastModifiedEpoch);
-  // YYYY-MM-DD string format compatible with qcalendar/selectedDate
-  // getMonth returns zero-based index so add 1 to get actual month number
   const lastModifiedTimeAndDate = reminderDate.toLocaleString();
 
   // UI reminder extension fields as a record, these are the actual values taken from frontend input fields 
@@ -1653,13 +1687,11 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
     temporaryFolderID: row.folderID == null ? null : ((typeof row.folderID === 'bigint') ? row.folderID : BigInt(row.folderID)),
     // Add on UI specific fields
     temporaryTitle: row.title ?? '',
-    // Replace this with actual extension fields later when support is added
     extension: extensionsUI,
     temporaryEventStartTime: startStr,
     temporaryEventEndTime: endStr,
     temporaryEventEndDay: normalizeDatePickerToCalendar(endDateString) ?? dateString, // Default end day is same as start day (not multi-day)
     temporaryEventEndDateEnabled: isMultiDayEvent, // Default not multi-day event
-    // If theres a notification, temporary notification time is reminder notification minute of day 
     temporaryNotificationTime: minutesBeforeStartTime,
     temporaryLastModified: lastModifiedTimeAndDate,
     date: normalizeDatePickerToCalendar(dateString) ?? dateString,
@@ -1669,8 +1701,159 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
     isSaved: true,
     isEditing: false,
     isSelected: false,
-    // Set this true elsewhere later
     isRecurring: false,
+    expanded: true
+  } as UIReminder;
+
+  // If true, update (if existing) or insert (if not) UI reminder into global reminders array
+  if (upsert) {
+    // Compute index for a reminder for card display, use itemID as unique index
+    // Look for existing reminder in reminders array that matches the itemID of the converted reminder
+    const index = reminders.value.findIndex(reminder => String(reminder.itemID) === String(UIReminder.itemID));
+    if (index >= 0) {
+    // If found, replace preexisting reminder in array with new UI object
+    reminders.value[index] = UIReminder;
+  } else {
+    // If not found, add new UI object reminder to the array
+    reminders.value.push(UIReminder);
+  }
+}
+  return UIReminder;
+}
+
+
+// Map a DB recurring reminder row into the UI reminder shape needed for card display
+// Additional upsert parameter decides whether to add/update the global reminders array
+function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | MonthlyReminder | YearlyReminder, recurrenceType: 'daily' | 'weekly' | 'monthly' | 'yearly', upsert: boolean): UIReminder {
+  // All recurring reminders have these fields so their evaluation can go before the recurrence object building
+  // Compute series start date from DB row to display
+  // Get series start year,day, and min from DB row 
+  const seriesStartYear = Number(row.seriesStartYear);
+  const seriesStartDay = Number(row.seriesStartDay);
+  const seriesStartMin = Number(row.seriesStartMin);
+
+  // Start at january 1st of series year and add days to get the right month/day
+  const startDate = new Date(seriesStartYear, 0, 1);
+  startDate.setDate(startDate.getDate() + (seriesStartDay - 1));
+
+  // Convert date to YYYY-MM-DD string format compatible with qcalendar/selectedDate
+  const dateString = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')}-${String(startDate.getDate()).padStart(2, '0')}`;
+
+  // Compute series end date from DB row to display
+  // Get series end year,day, and min from DB row
+  const seriesEndYear = Number(row.seriesEndYear);
+  const seriesEndDay = Number(row.seriesEndDay);
+  const seriesEndMin = Number(row.seriesEndMin);
+  const endDate = new Date(seriesEndYear, 0, 1);
+  endDate.setDate(endDate.getDate() + (seriesEndDay - 1));
+  const endDateString = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}`;
+
+  // Get last modified and convert for display
+  const lastModifiedEpoch = Number(row.lastModified);
+  const recurringReminderDate = new Date(lastModifiedEpoch);
+  const lastModifiedTimeAndDate = recurringReminderDate.toLocaleString();
+
+  // Build recurrence object for UI based on recurrence type
+  let recurrence: UIReminder['recurrence'] = null;
+
+  if (recurrenceType === 'daily') {
+    // If recurrence type is daily, treat DB row as daily reminder schema
+    const dailyReminder = row as DailyReminder;
+    recurrence = {
+      type: 'daily',
+      daily: {
+        timeOfDayMin: dailyReminder.seriesStartMin,
+        eventDurationMin: dailyReminder.eventDurationMin,
+        notifOffsetTimeMin: dailyReminder.notifOffsetTimeMin,
+        everyNDays: dailyReminder.everyNDays,
+        seriesEndDate: normalizeDatePickerToCalendar(endDateString) ?? endDateString
+      }
+    };
+  }
+
+  // UI reminder extension fields as a record, these are the actual values taken from frontend input fields 
+  const extensionsUI = {} as Record<string, string | number | null | undefined>;
+
+  // DB reminder row with extensions
+  const extensionsArr = (row as DailyReminder & { extensions?: Extension[] }).extensions;
+
+  // If extensions array exists, map each extension into extensions UI record
+  if (extensionsArr && extensionsArr.length > 0) {
+    // If a flight, extract flight fields
+    if (row.eventType === 1) {
+      const flightFields = ExtensionsToFlight(extensionsArr);
+      console.log('flightFields', flightFields, 'extensionsUI', extensionsUI);
+      if (flightFields) {
+        extensionsUI.depAirportName = stripNulls(flightFields.depAirportName ?? '');
+        extensionsUI.depAirportAddress = stripNulls(flightFields.depAirportAddress ?? '');
+        extensionsUI.arrAirportName = stripNulls(flightFields.arrAirportName ?? '');
+        extensionsUI.arrAirportAddress = stripNulls(flightFields.arrAirportAddress ?? '');
+        extensionsUI.airlineCode = stripNulls(flightFields.airlineCode ?? '');
+        extensionsUI.flightNumber = stripNulls(flightFields.flightNumber ?? '');
+        extensionsUI.airlineName = stripNulls(flightFields.airlineName ?? '');
+        extensionsUI.depAirportIATA = stripNulls(flightFields.depAirportIATA ?? '');
+        extensionsUI.depTime = minutesToHHMM(flightFields.depTimeMin);
+        extensionsUI.boardingTime = minutesToHHMM(flightFields.boardingTimeMin);
+        extensionsUI.boardingGroup = stripNulls(flightFields.boardingGroup ?? '');
+        extensionsUI.gate = stripNulls(flightFields.gate ?? '');
+        extensionsUI.arrAirportIATA = stripNulls(flightFields.arrAirportIATA ?? '');
+        extensionsUI.arrTime = minutesToHHMM(flightFields.arrTimeMin);
+      }
+    }
+    // If a hotel, extract hotel fields
+    else if (row.eventType === 2) {
+      const hotelFields = ExtensionsToHotel(extensionsArr);
+      if (hotelFields) {
+        extensionsUI.name = stripNulls(hotelFields.name ?? '');
+        extensionsUI.address = stripNulls(hotelFields.address ?? '');
+        extensionsUI.checkinTime = minutesToHHMM(hotelFields.checkinTimeMin);
+        extensionsUI.checkoutTime = minutesToHHMM(hotelFields.checkoutTimeMin);
+        extensionsUI.roomNumber = stripNulls(hotelFields.roomNumber ?? '');
+    }
+  }
+}
+
+ // Need to add fields to the DB reminder row specific to the UI card
+ // Sets temporary fields to saved values from DB
+  const UIReminder = {
+    // Copy all fields from DB shared type (daily, weekly, monthly, or yearly depending on what recurrence was passed in)
+    ...row,
+    // normalize itemID and folder IDs to bigint so they match folder IDs used by the tree
+    itemID: (typeof row.itemID === 'bigint') ? row.itemID : BigInt(row.itemID),
+    folderID: (typeof row.folderID === 'bigint') ? row.folderID : BigInt(row.folderID),
+    temporaryFolderID: row.folderID == null ? null : ((typeof row.folderID === 'bigint') ? row.folderID : BigInt(row.folderID)),
+    // Add on UI specific fields
+    temporaryTitle: row.title ?? '',
+    extension: extensionsUI,
+
+    // Event start time, end time, end day, end date are all unique to non-recurring reminders, override these fields for recurring 
+    temporaryEventStartTime: '',
+    temporaryEventEndTime: '',
+    temporaryEventEndDay: '', // No multi-day support for recurring
+    temporaryEventEndDateEnabled: false, // No multi-day support for recurring
+    // Temp notification time is same as notifOffsetTimeMin for recurring reminders (but positive)
+    temporaryNotificationTime: ('notifOffsetTimeMin' in row) ? Math.abs(row.notifOffsetTimeMin ?? 0) : null,
+    eventStartYear: row.seriesStartYear,
+    eventStartDay: row.seriesStartDay,
+    eventStartMin: row.seriesStartMin,
+    eventEndYear: row.seriesEndYear,
+    eventEndDay: row.seriesEndDay,
+    eventEndMin: row.seriesEndMin,
+    notifYear: 0,
+    notifDay: 0,
+    notifMin: 0,
+    hasNotif: row.hasNotifs,
+
+    temporaryLastModified: lastModifiedTimeAndDate,
+    date: normalizeDatePickerToCalendar(dateString) ?? dateString,
+    titleMessageError: '',
+    folderMessageError: '',
+    timeMessageError: '',
+    isSaved: true,
+    isEditing: false,
+    isSelected: false,
+    recurrence: recurrence,
+    isRecurring: true,
     expanded: true
   } as UIReminder;
 
@@ -1791,9 +1974,11 @@ onMounted(async () => {
   await addRootFolder();
   // Ensure folders array is populated from local DB on page load
   folders.value = mapDBToUIFolder(await readAllFolders());
-  // Load all reminders and notes so tree shows every item
+  // Load all reminders and notes for file explorer tree
   await loadReminders();
   await loadNotes();
+  // Load recurring series for file explorer tree
+  await loadRecurringSeries();
   // Load reminders for selected calendar date on startup for tab list
   await loadRemindersForCalendarDate(selectedDate.value);
   // Load reminders for the visible month for calendar events
@@ -2061,29 +2246,47 @@ async function saveRecurringReminder(reminder: UIReminder) {
     const extensionsToSend = (extensions && extensions.length > 0) ? extensions : undefined;
       // Recurring reminder not saved to DB yet, create it
       if (!reminder.isSaved) {
-      const seriesID = await createDailyReminder(reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
+        const seriesID = await createDailyReminder(reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
 
-        // Since recurring is not displayed in list/calendar (not mapped to UI card), update series ID and isSaved
+        // Make sure draft ID matches DB ID so it gets replaced in UI
         reminder.itemID = seriesID;
         reminder.isSaved = true;
 
+        // Fetch the newly created recurring reminder from the DB 
+        const row = await readDailyReminder(seriesID);
+        
+        // Map recurring reminder to UI format
+        if (row) {
+          mapDBSeriesToUIRecurringReminder(row, 'daily', true);
+        };
+
+        // Load folders after creation
         folders.value = mapDBToUIFolder(await readAllFolders());
         reminder.timeMessageError = '';
         return true;
       }
+
       // Recurring reminder saved before, update it
       else {
-          await updateDailyReminder(reminder.itemID, reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
-          folders.value = mapDBToUIFolder(await readAllFolders());
-          reminder.timeMessageError = '';
-          return true;
+        await updateDailyReminder(reminder.itemID, reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
+
+        // Fetch the updated recurring reminder from the DB 
+        const row = await readDailyReminder(reminder.itemID);
+
+        // Map recurring reminder to UI format
+        if (row) {
+          mapDBSeriesToUIRecurringReminder(row, 'daily', true);
+        };
+
+        folders.value = mapDBToUIFolder(await readAllFolders());
+        reminder.timeMessageError = '';
+        return true;
       }
     }
     catch (err) {
       console.error('Error saving recurring reminder.');
       return false;
     }
-
   }
 }
 
@@ -2247,8 +2450,6 @@ try {
   //console.log('Saving reminder extensions:', extensions);
   // Create base reminder in local DB and retrieve the itemID assigned to it
   const itemID = await createReminder(reminder.temporaryFolderID, reminder.eventType, eventStartTime, eventEnd, notificationTimestampToSend, hasNotification, reminder.temporaryTitle, extensionsToSend);
-  console.log('DBG SAVE payload', { idTemp: reminder.itemID, eventType: reminder.eventType, eventStartTime, eventEnd, extensionsToSend });
-  console.log('Reminder successfully created:', String(itemID));
 
   // Fetch the newly created reminder from the DB 
   const row = await readReminder(itemID);
@@ -2541,18 +2742,47 @@ const filteredReminders = computed(() => {
   // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
   const query = (searchQuery.value ?? '').trim().toLowerCase();
 
-  // Filter out recurring reminders from reminder list for middle list display
-  // Only when not saved, must allow drafts to create the recurrence
-  //const noRecurringReminders = reminders.value.filter(reminder => !reminder.isRecurring || !reminder.isSaved);
-  const noRecurringReminders = reminders.value;
+  // By default, middle list only shows normal reminders and recurring drafts
+  const defaultReminderList = reminders.value.filter(reminder => !reminder.isRecurring || !reminder.isSaved);
 
+  /*
+  // Only show normal reminders and recurring drafts in middle list
+  const visibleReminders = reminders.value.filter(reminder => {
+    // Show saved recurring in middle list temporarily only if selected on the file explorer
+    if (reminder.isRecurring && reminder.isSaved) {
+      // Checks for a tree node selection (tree nodes use negative itemID)
+      if (selectedFolderID.value !== null && selectedFolderID.value < 0n) {
+        const selectedNode = -selectedFolderID.value;
+        // Check if the selected tree node ID (converted to positive) matches the reminder itemID
+        if (String(reminder.itemID) === String(selectedNode)) {
+        }
+
+      
+    }
+    return true;
+  });
+  */
+
+ // const noRecurringReminders = reminders.value;
+
+ // No search query, either show recurring reminder if selected on file explorer
+ // Or show default list otherwise (normal reminders and recurring drafts)
   if (!searchQuery.value) {
-    // If no search query, default show reminders for selected calendar date
-    return noRecurringReminders.filter(reminder => reminder.date === selectedDate.value);
+    if (selectedFolderID.value !== null && selectedFolderID.value < 0n) {
+      const selectedNode = -selectedFolderID.value;
+      // Check if the selected tree node ID (converted to positive) matches a recurring reminder itemID
+      const recurringReminder = reminders.value.find(reminder => String(reminder.itemID) === String(selectedNode) && reminder.isRecurring && reminder.isSaved);
+      if (recurringReminder) {
+        return [recurringReminder];
+      }
+    }
+    else {
+      return defaultReminderList.filter(reminder => reminder.date === selectedDate.value);
+    }
   }
 
-  // Otherwise, filter reminders based on the search query (title)
-  return noRecurringReminders.filter(reminder => {
+  // Otherwise, if search query is provided, only search normal reminders and recurring drafts (default list) by title
+  return defaultReminderList.filter(reminder => {
     // Check for reminders entries where the title is in the search query
     const matchesQuery = String(reminder.temporaryTitle ?? '').toLowerCase().includes(query) || String(reminder.title ?? '').toLowerCase().includes(query);
     // Return true if both date and query match

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -372,7 +372,7 @@
                   label="Series End Date"
                   type="date"
                   :min="item.date"
-                  :max="endDateRangeRecurring(item.date)"
+                  :max="endDateRangeRecurring(item.date, selectedDate)"
                   outlined
                   dense
                   style="background-color: #f2f2f2; margin-bottom: 10px"
@@ -423,7 +423,7 @@
                   label="Series End Date"
                   type="date"
                   :min="item.date"
-                  :max="endDateRangeRecurring(item.date)"
+                  :max="endDateRangeRecurring(item.date, selectedDate)"
                   outlined
                   dense
                   style="background-color: #f2f2f2; margin-bottom: 10px"
@@ -489,7 +489,7 @@
                   label="Series End Date"
                   type="date"
                   :min="item.date"
-                  :max="endDateRangeRecurring(item.date)"
+                  :max="endDateRangeRecurring(item.date, selectedDate)"
                   outlined
                   dense
                   style="background-color: #f2f2f2; margin-bottom: 10px"
@@ -528,7 +528,7 @@
                   label="Series End Date"
                   type="date"
                   :min="item.date"
-                  :max="endDateRangeRecurring(item.date)"
+                  :max="endDateRangeRecurring(item.date, selectedDate)"
                   outlined
                   dense
                   style="background-color: #f2f2f2; margin-bottom: 10px"
@@ -561,8 +561,8 @@
                         type="date"
                         label="Event End Date"
                         v-model="item.temporaryEventEndDay"
-                        :min="endDateRange(item.date).min"
-                        :max="endDateRange(item.date).max"
+                        :min="endDateRange(item.date, selectedDate).min"
+                        :max="endDateRange(item.date, selectedDate).max"
                         style="font-size: 12px; background-color: #f2f2f2; margin-bottom: 8px;"
                       >
                       </q-input>
@@ -639,8 +639,8 @@
                       outlined
                       dense
                       type="date" 
-                      :min="endDateRange(item.date).min"
-                      :max="endDateRange(item.date).max"
+                      :min="endDateRange(item.date, selectedDate).min"
+                      :max="endDateRange(item.date, selectedDate).max"
                       class="flight-full"
                       style="width: 100%"
                     />
@@ -764,8 +764,8 @@
                     type="date"
                     label="Check-out Date"
                     v-model="item.temporaryEventEndDay"
-                    :min="endDateRange(item.date).min"
-                    :max="endDateRange(item.date).max"
+                    :min="endDateRange(item.date, selectedDate).min"
+                    :max="endDateRange(item.date, selectedDate).max"
                     style="width:100%;"
                     class = "flight-full"
                   />
@@ -816,9 +816,11 @@
               <div v-if="item.timeMessageError" style="color: #f44336; font-size: 13px; margin-bottom: 8px;">
                 {{ item.timeMessageError }}
               </div>
-                <div class="row">
+                <div class="row" style="display:flex; flex-wrap:wrap; align-items:center">
                   <q-btn class="login-register-button" style="font-size: 15px; margin-right: 10px" flat label="Save" @click="saveReminder(item)"></q-btn>
                   <q-btn class="login-register-button" style="background-color: grey; font-size: 15px" flat label="Cancel" @click="cancelReminder(item)"></q-btn>
+                  <q-btn v-if="item.isGenerated" class="login-register-button" style="font-size: 15px" flat label="View Series" @click="showParentSeriesFromGeneratedReminder(item)"></q-btn>
+                  <q-btn v-if="item.isRecurring && previousListState && String(previousListState.parentSeriesID) === String(item.itemID)" class="login-register-button" style="background-color: grey; font-size: 15px" flat label="View Generated" @click="showGeneratedReminderFromParentSeries()"></q-btn>
                 </div>
               </q-card-section>
             </q-expansion-item>
@@ -944,11 +946,12 @@
 </template>
 
 <script setup lang="ts">
+// Imports
 import {QCalendarMonth, addToDate, parseTimestamp, today, isLeapYear, type Timestamp} from '@quasar/quasar-ui-qcalendar';
 import '@quasar/quasar-ui-qcalendar/index.css';
-import {buildCalendarEvents, groupEventsByDate, getEventTypeColor, getEventTypeFields, getEventStartLabel, getEventEndLabel, type EventType, type CalendarEvent} from '../frontend-utils/events';
+import {buildCalendarEvents, groupEventsByDate, getEventTypeColor, getEventTypeFields, getEventStartLabel, stripNulls, getEventEndLabel, type EventType, type CalendarEvent} from '../frontend-utils/events';
 import { buildBreadcrumbs, normalizeFolderID, buildRootNodes} from '../frontend-utils/tree';
-import { convertTimeAndDateToTimestamp, convertNotificationTimestamp, minutesToHHMM, timeStamptoEpoch, normalizeDatePickerToCalendar, eventDatetoLocaleString } from '../frontend-utils/time';
+import { convertTimeAndDateToTimestamp, convertNotificationTimestamp, minutesToHHMM, timeStamptoEpoch, normalizeDatePickerToCalendar, eventDatetoLocaleString, endDateRange, endDateRangeRecurring } from '../frontend-utils/time';
 import { ref, computed, watch, onMounted } from 'vue';
 import type { UINote, UIReminder, UIFolder } from '../types/ui-types';
 import type { Reminder, DailyReminder, WeeklyReminder, MonthlyReminder, YearlyReminder, GeneratedReminder, Note, Folder, Extension } from '../../src-electron/types/shared-types';
@@ -963,97 +966,137 @@ import { ValidateFlight, ValidateHotel } from '../utils/validate';
 
 // Initialize active tab to reminder by default
 const tab = ref('reminders');
-const settingsTab = ref('cloud');
+// Array of normal, recurring, and generated reminders for list and file explorer
 const reminders = ref<UIReminder[]>([])
-// Array of reminders by month for calendar
+// Array of reminders loaded by month specifically for calendar
 const monthReminders = ref<UIReminder[]>([])
+// Array of notes
+const notes = ref<UINote[]>([])
 // Stores the array of full dates selected in qdate component for monthly recurrence
-const DaysOfMonthSelection = ref<string[]>([]);  
+const DaysOfMonthSelection = ref<string[]>([]);
+const selectAll = ref(false)
+const searchQuery = ref('');
+// Used to store the middle list state when viewing a parent series from generated to be able to go back 
+const previousListState = ref<{
+  // Switch to correct calendar date
+  calendarDate: string;
+  // Route back to generated card from parent series
+  generatedID: bigint;
+  // Route to parent series from generated card
+  parentSeriesID: bigint;
+} | null>(null);
 
-// Extract just the days from the full dates of the DaysOfMonthSelection
-// Use these days to set the daysOfMonth array in the MonthlyReminder recurrence 
-// Computed so that it updates automatically when DaysOfMonthSelection changes
-const selectedDayOfMonth = computed(() => {
-  // If daysOfMonthSelection is missing or empty, show empty string
-  if (!DaysOfMonthSelection.value || DaysOfMonthSelection.value.length === 0) {
-    return '';
+// Filtered reminder array for displaying only reminders that match the selected calendar date or search query
+const filteredReminders = computed(() => {
+  // Normalize search query: remove whitespace and convert to lowercase for case-insensitive matching
+  // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
+  const query = (searchQuery.value ?? '').trim().toLowerCase();
+
+  // By default, middle list only shows normal reminders and recurring drafts (or saved reminders being converted to recurring)
+  const defaultReminderList = reminders.value.filter(reminder => !reminder.isRecurring || !reminder.isSaved || reminder.isConverting);
+
+ // No search query, either show recurring reminder if selected on file explorer
+ // Or show default list otherwise (normal reminders and recurring drafts)
+  if (!searchQuery.value) {
+    if (selectedFolderID.value !== null && selectedFolderID.value < 0n) {
+      const selectedNode = -selectedFolderID.value;
+      // Check if the selected tree node ID (converted to positive) matches a recurring reminder itemID
+      const recurringReminder = reminders.value.find(reminder => String(reminder.itemID) === String(selectedNode) && reminder.isRecurring && reminder.isSaved);
+      if (recurringReminder) {
+        return [recurringReminder];
+      }
+    }
+    else {
+      return defaultReminderList.filter(reminder => reminder.date === selectedDate.value);
+    }
   }
-   const days = DaysOfMonthSelection.value.map(dateString => {
-    // Split each date string ex. "YYYY/MM/DD" in the array by '/' delimiter to get each part
-    const parts = dateString.split('/');
 
-    // Last part is the day component "DD"
-    const dayPart = parts[2] ?? '';
-
-    // Convert the day string "DD" to an integer to get rid of leading zeros like "01" for q-input display
-    return parseInt(dayPart, 10);
-    // Sort the days numerically in ascending order for q-input display
-  }).sort((a, b) => a - b); 
-
-  // Join back the stripped day numbers into a comma-separated string for q-input display
-  return days.join(', ');
+  // Otherwise, if search query is provided, only search normal reminders and recurring drafts (default list) by title
+  return defaultReminderList.filter(reminder => {
+    // Check for reminders entries where the title is in the search query
+    const matchesQuery = String(reminder.temporaryTitle ?? '').toLowerCase().includes(query) || String(reminder.title ?? '').toLowerCase().includes(query);
+    // Return true if both date and query match
+    return matchesQuery;
+  });
 });
 
-// Helper function to determine days user can pick for event end day (from start day to one year later)
-// Hard limits reminders to +1 year from start date for event duration
-function endDateRange(startDate: string): { min: string; max: string } {
-  // Normalize inputted date string to yyyy-mm-dd format
-  let dateString = normalizeDatePickerToCalendar(startDate ?? '') || '';
-  // If provided startDate is empty/invalid, fallback to currently selected calendar date
-  if (!dateString) {
-    dateString = normalizeDatePickerToCalendar(String(selectedDate.value ?? '')) || '';
+// Filtered notes array for displaying only notes that match the search query
+const filteredNotes = computed(() => {
+  // Normalize search query: remove whitespace and convert to lowercase for case-insensitive matching
+  // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
+  const query = (searchQuery.value ?? '').trim().toLowerCase();
+  if (!searchQuery.value) {
+    // If no search query, default show all the notes
+    return notes.value;
   }
 
-  if (dateString) {
-    const [yearString, monthString, dayString] = dateString.split('-');
-    const year = Number(yearString);
-    const month = Number(monthString);
-    const day = Number(dayString);
-    // Create a new start date object from inputted start date with 0 hours, minutes, seconds to compare full day
-    const sDate = new Date(year, month - 1, day);
-    sDate.setHours(0, 0, 0, 0);
+  // Otherwise, filter notes based on the search query (title)
+  return notes.value.filter(note => {
+    // Check for note entries where the title is in the search query
+    const matchesQuery = String(note.temporaryTitle ?? '').toLowerCase().includes(query) || String(note.title ?? '').toLowerCase().includes(query);
+    return matchesQuery;
+  });
+  });
 
-    const endDate = new Date(sDate);
-    // Takes the start date (0 time) and adds 365 days to it for max end date
-    endDate.setDate(endDate.getDate() + 365);
-
-    const startString = `${sDate.getFullYear()}-${String(sDate.getMonth() + 1).padStart(2, '0')}-${String(sDate.getDate()).padStart(2, '0')}`;
-    const endString = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}`;
-
-    // Return the min and max date strings in yyyy-mm-dd format for date picker
-    return { min: startString, max: endString };
+// Function to show the parent series in middle list linked to generated reminder
+// Occurs when user clicks navigate to parent from a generated reminder card
+function showParentSeriesFromGeneratedReminder(generatedReminder: UIReminder) {
+  // Not a generated reminder or linked parent ID is missing
+  if (!generatedReminder || generatedReminder.linkedParentSeriesID == null) {
+    return;
   }
 
-  // If input is invalid or empty, return empty strings to satisfy the declared return type
-  return { min: '', max: '' };
+  // Save current default list view (generated + normal reminders) before switching to series view
+  previousListState.value = {
+    calendarDate: selectedDate.value,
+    generatedID: generatedReminder.itemID,
+    parentSeriesID: generatedReminder.linkedParentSeriesID
+  }
+
+  // Try to find parent series reminder linked to this generated reminder
+  const parentSeries = reminders.value.find(reminder => String(reminder.itemID) === String(generatedReminder.linkedParentSeriesID))
+  // Return if parent cannot be found
+  if (!parentSeries) {
+    return;
+  }
+
+  // Parent found, switch middle list view to show the generated reminders parent series
+  tab.value = 'reminders';
+  // Route to the date that the series was created on
+  selectedDate.value = parentSeries.date;
+  // Select parent series on file explorer so filteredReminders shows the series in the middle
+  selectedFolderID.value = -parentSeries.itemID; 
+  // Collapse all other reminders and expand parent series
+  reminders.value.forEach(reminder => reminder.expanded = false);
+  parentSeries.expanded = true
 }
 
-// Helper function to determine days user can pick for series end day (from start day to 100 years later)
-function endDateRangeRecurring(startDate: string) {
-  let dateString = normalizeDatePickerToCalendar(startDate ?? '') || '';
-  // If provided startDate is empty/invalid, fallback to currently selected calendar date
-  if (!dateString) {
-    dateString = normalizeDatePickerToCalendar(String(selectedDate.value ?? '')) || '';
+// Function to return back to middle list (normal reminders and generated) from parent series card
+function showGeneratedReminderFromParentSeries() {
+  if (!previousListState.value) {
+    return;
   }
+  
+  // Restore calendar date back to previous calendar-selected generated reminders date
+  selectedDate.value = previousListState.value.calendarDate;
 
-  if (dateString) {
-    const [yearString, monthString, dayString] = dateString.split('-');
-    const year = Number(yearString);
-    const month = Number(monthString);
-    const day = Number(dayString);
-    // Create a new start date object from inputted start date with 0 hours, minutes, seconds to compare full day
-    const sDate = new Date(year, month - 1, day);
-    sDate.setHours(0, 0, 0, 0);
+  // Unselect the parent file explorer node
+  selectedFolderID.value = null;
 
-    const endDate = new Date(sDate);
-    // Takes the start date (0 time) and add 100 years for end date
-    endDate.setFullYear(endDate.getFullYear() + 100);
-    const endString = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}`;
-
-    return endString;
+  // Find the generated reminder thats a child of the parent series from before
+  const generated = reminders.value.find(reminder => String(reminder.itemID) === String(previousListState.value!.generatedID))
+  // If found, collapse all other reminders and expand the generated
+  if (generated) {
+    tab.value = 'reminders';
+    reminders.value.forEach(reminder => reminder.expanded = false);
+    generated.expanded = true;
+    // Clear out saved list state view
+    previousListState.value = null;
+    return;
   }
 }
 
+// Notification and dropdown variables/functions
 // List of notification options for when to be notified for reminder
 // Value is minutes before the event start time
 const notificationOptions = [
@@ -1132,9 +1175,7 @@ const daysOfWeekOptions = [
     }
   }
 
-// Array of notes
-const notes = ref<UINote[]>([])
-
+// Event type variables/functions
 // Object of event types for UI
 const eventTypes: EventType[] = [
    {
@@ -1253,8 +1294,6 @@ const eventTypes: EventType[] = [
     // Neither of the times have set values, return undefined, treat as empty
     return undefined;
   };
-
-
     // Flight
     switch (reminder.eventType) {
       case 1: {
@@ -1331,6 +1370,8 @@ const eventTypeOptions = computed(() => {
   }));
 });
 
+// Settings and cloud sync variables/functions
+const settingsTab = ref('cloud');
 const showSettings = ref(false);
 const showLoginOptions = ref(false);
 const showChangeLogin = ref(false);
@@ -1366,6 +1407,29 @@ async function onToggleCloudSync() {
   }
 }
 
+// Change icon depending on cloud sync status
+const cloudIcon = computed(() => {
+  // Cloud toggle is off
+  if (!isCloudOn.value) {
+    return 'cloud_off'
+  }
+  // Currently syncing
+  if (isSyncing.value) {
+    return 'cloud_sync'
+  }
+  // Sync successful
+  if (syncStatusMessage.value === 'Cloud Synced Successfully') {
+    return 'cloud_done'
+  }
+  // Sync failed
+  if (syncStatusMessage.value === 'Cloud Sync Failed') {
+    return 'cloud_off'
+  }
+  // Default
+  return 'cloud'
+})
+
+// Main functionality (CRUD on recurrence, generated, normal reminders and notes)
 // Since a recurrence is an optional property, function to safely toggle checkbox
 function onToggleRecurrenceType(item: UIReminder, enabled: boolean) {
   // isRecurring property uses checkbox value from user
@@ -1455,36 +1519,30 @@ else if (val === 'weekly' && !recurrence.weekly) {
   }}
 }
 
+// Extract just the days from the full dates of the DaysOfMonthSelection
+// Use these days to set the daysOfMonth array in the MonthlyReminder recurrence 
+// Computed so that it updates automatically when DaysOfMonthSelection changes
+const selectedDayOfMonth = computed(() => {
+  // If daysOfMonthSelection is missing or empty, show empty string
+  if (!DaysOfMonthSelection.value || DaysOfMonthSelection.value.length === 0) {
+    return '';
+  }
+   const days = DaysOfMonthSelection.value.map(dateString => {
+    // Split each date string ex. "YYYY/MM/DD" in the array by '/' delimiter to get each part
+    const parts = dateString.split('/');
 
-// Change icon depending on cloud sync status
-const cloudIcon = computed(() => {
-  // Cloud toggle is off
-  if (!isCloudOn.value) {
-    return 'cloud_off'
-  }
-  // Currently syncing
-  if (isSyncing.value) {
-    return 'cloud_sync'
-  }
-  // Sync successful
-  if (syncStatusMessage.value === 'Cloud Synced Successfully') {
-    return 'cloud_done'
-  }
-  // Sync failed
-  if (syncStatusMessage.value === 'Cloud Sync Failed') {
-    return 'cloud_off'
-  }
-  // Default
-  return 'cloud'
-})
+    // Last part is the day component "DD"
+    const dayPart = parts[2] ?? '';
 
-const selectAll = ref(false)
-const searchQuery = ref('');
-const newUsername = ref<string>('');
-const newPassword = ref<string>('');
-const isPwd = ref(true);
-const $q = useQuasar();
-const router = useRouter();
+    // Convert the day string "DD" to an integer to get rid of leading zeros like "01" for q-input display
+    return parseInt(dayPart, 10);
+    // Sort the days numerically in ascending order for q-input display
+  }).sort((a, b) => a - b); 
+
+  // Join back the stripped day numbers into a comma-separated string for q-input display
+  return days.join(', ');
+});
+
 
 // Specific folder ID currently selected in the file explorer tree, tracked for adding folder in that specific spot
 // null is if there is no folder selected on the tree, this by default
@@ -1500,7 +1558,6 @@ const folderDropdownOptions = computed(() => {
     value: folder.folderID
   }));
 });
-
 
 // Function to get reminder by its ID
 function getReminder(id?: bigint | null): UIReminder | null {
@@ -1869,7 +1926,7 @@ async function loadGeneratedReminders(dateString: string) {
 
     // Read the viewable calendar month
     const currentMonthReminders = await readGeneratedRemindersInRange(startRange, endRange);
-    console.log('📅 Current month generated reminders from DB:', currentMonthReminders.length, currentMonthReminders); // DEBUG
+    //console.log('Current month generated reminders from DB:', currentMonthReminders.length, currentMonthReminders); // DEBUG
     // Convert each generated reminder in range from response to UI reminder format 
     for (const generatedReminder of currentMonthReminders) {
       // Map to UI and push to middle list (reminders array)
@@ -1880,17 +1937,13 @@ async function loadGeneratedReminders(dateString: string) {
 
     // Read the next month after
     const nextMonthReminders = await readGeneratedRemindersInRange(nextMonthStartRange, nextMonthEndRange);
-     console.log('📅 Next month generated reminders from DB:', nextMonthReminders.length, nextMonthReminders); // DEBUG
+    //console.log('Next month generated reminders from DB:', nextMonthReminders.length, nextMonthReminders); // DEBUG
     // Convert each generated reminder in range from response to UI reminder format
     for (const generatedReminder of nextMonthReminders) {
       // Map to UI and push to middle list (reminders array)
       // Do not push to monthReminders since its not in the current month view
       mapDBGeneratedToUIReminder(generatedReminder, true);
     }
-
-    console.log('✅ Total generated reminders in reminders.value:', reminders.value.filter(r => r.isGenerated).length); // DEBUG
-    console.log('Generated reminders:', reminders.value.filter(r => r.isGenerated)); // DEBUG
-
   } catch (error) {
     console.error('Error loading reminders for month:', error);
   } 
@@ -2015,12 +2068,7 @@ async function addRootFolder() {
   }
 }
 
-// Remove padding null characters from extension strings received by database for UI display
-function stripNulls(fieldString?: string | null): string {
-  // Globally replace all null characters with empty string and trim whitespace
-  return (fieldString ?? '').replace(/\0/g, '').trim();
-}
-
+// Mapper functions to map database rows to UI
 // Map a DB reminder row into the UI reminder shape needed for card display
 // Additional upsert parameter decides whether to add/update the global reminders array
 function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
@@ -2321,8 +2369,6 @@ function mapDBGeneratedToUIReminder(row: GeneratedReminder, upsert: boolean): UI
 }
   return UIReminder;
 }
-
-
 
 // Map a DB recurring reminder row into the UI reminder shape needed for card display
 // Additional upsert parameter decides whether to add/update the global reminders array
@@ -3967,19 +4013,7 @@ async function cancelNote(note: UINote) {
   }
 }
 
-// Watcher on the checkbox to select and deselect all reminders or notes when select all checkbox is toggled
-watch(selectAll, (selectionVal) => {
-  if (tab.value === 'reminders') {
-    filteredReminders.value.forEach(reminder => {
-      reminder.isSelected = selectionVal;
-    });
-  } else if (tab.value === 'notes') {
-    notes.value.forEach(note => {
-      note.isSelected = selectionVal;
-    });
-  }
-});
-
+// Calendar functionality and watchers
 // template and script source code from slot - day month example
 // https://qcalendar.netlify.app/developing/qcalendar-month
 const calendar = ref<QCalendarMonth>(),
@@ -3992,48 +4026,6 @@ const formattedMonth = computed(() => {
   const formatter = monthFormatter()
   return formatter ? formatter.format(date) : ''
 })
-
-// Filtered reminder array for displaying only reminders that match the selected calendar date or search query
-const filteredReminders = computed(() => {
-  //return reminders.value.filter(reminder => reminder.date === selectedDate.value)
-  // Normalize search query: remove whitespace and convert to lowercase for case-insensitive matching
-  // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
-  const query = (searchQuery.value ?? '').trim().toLowerCase();
-
-  // By default, middle list only shows normal reminders and recurring drafts (or saved reminders being converted to recurring)
-  const defaultReminderList = reminders.value.filter(reminder => !reminder.isRecurring || !reminder.isSaved || reminder.isConverting);
-
- // No search query, either show recurring reminder if selected on file explorer
- // Or show default list otherwise (normal reminders and recurring drafts)
-  if (!searchQuery.value) {
-    if (selectedFolderID.value !== null && selectedFolderID.value < 0n) {
-      const selectedNode = -selectedFolderID.value;
-      // Check if the selected tree node ID (converted to positive) matches a recurring reminder itemID
-      const recurringReminder = reminders.value.find(reminder => String(reminder.itemID) === String(selectedNode) && reminder.isRecurring && reminder.isSaved);
-      if (recurringReminder) {
-        return [recurringReminder];
-      }
-    }
-    else {
-      return defaultReminderList.filter(reminder => reminder.date === selectedDate.value);
-    }
-  }
-
-  // Otherwise, if search query is provided, only search normal reminders and recurring drafts (default list) by title
-  return defaultReminderList.filter(reminder => {
-    // Check for reminders entries where the title is in the search query
-    const matchesQuery = String(reminder.temporaryTitle ?? '').toLowerCase().includes(query) || String(reminder.title ?? '').toLowerCase().includes(query);
-    // Return true if both date and query match
-    return matchesQuery;
-  });
-});
-
-// Reload list of reminders whenever the selected calendar date changes
-watch(selectedDate, async (newDate) => {
-  // Load reminders for newly selected calendar date
-  await loadRemindersForCalendarDate(newDate);
-  await loadGeneratedReminders(newDate);
-});
 
 // Create events on calendar from reminders
 const events = computed(() => buildCalendarEvents(monthReminders.value, eventTypes))
@@ -4053,24 +4045,25 @@ function onClickCalendarEvent(event: CalendarEvent) {
   reminder.expanded = true;
 }
 
-// Filtered notes array for displaying only notes that match the search query
-const filteredNotes = computed(() => {
-  // Normalize search query: remove whitespace and convert to lowercase for case-insensitive matching
-  // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
-  const query = (searchQuery.value ?? '').trim().toLowerCase();
-  if (!searchQuery.value) {
-    // If no search query, default show all the notes
-    return notes.value;
+// Watcher on the checkbox to select and deselect all reminders or notes when select all checkbox is toggled
+watch(selectAll, (selectionVal) => {
+  if (tab.value === 'reminders') {
+    filteredReminders.value.forEach(reminder => {
+      reminder.isSelected = selectionVal;
+    });
+  } else if (tab.value === 'notes') {
+    notes.value.forEach(note => {
+      note.isSelected = selectionVal;
+    });
   }
+});
 
-  // Otherwise, filter notes based on the search query (title)
-  return notes.value.filter(note => {
-    // Check for note entries where the title is in the search query
-    const matchesQuery = String(note.temporaryTitle ?? '').toLowerCase().includes(query) || String(note.title ?? '').toLowerCase().includes(query);
-    return matchesQuery;
-  });
-  });
-
+// Reload list of reminders whenever the selected calendar date changes
+watch(selectedDate, async (newDate) => {
+  // Load reminders for newly selected calendar date
+  await loadRemindersForCalendarDate(newDate);
+  await loadGeneratedReminders(newDate);
+});
 
 // Watcher to unselect the select all checkbox if there are no reminders or notes in the array (ex. none made or after deletion)
 watch([filteredReminders, notes, tab], () => {
@@ -4157,6 +4150,12 @@ function onClickHeadWorkweek(data: Timestamp) {
   console.info('onClickHeadWorkweek', data)
 }
 
+// Account variables/functions
+const newUsername = ref<string>('');
+const newPassword = ref<string>('');
+const isPwd = ref(true);
+const $q = useQuasar();
+const router = useRouter();
 async function logout()
 {
   try {
@@ -4212,5 +4211,4 @@ async function saveLoginChanges() {
   }
 
 }
-
 </script>

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-19
+ * Updated: 2025-11-20
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -289,7 +289,8 @@
                 style="background-color: #f2f2f2; margin-bottom: 10px"
               />
               <q-select
-                v-model="item.temporaryNotificationTime"
+                :model-value="getNotificationOffset(item)"
+                @update:model-value="val => setNotificationOffset(item, val)"
                 :options="notificationOptions"
                 label="Remind me:"
                 emit-value 
@@ -867,6 +868,54 @@ const recurrenceOptions = [
   { label: 'Monthly', value: 'monthly' },
   { label: 'Yearly', value: 'yearly' }
   ];
+
+  // Function to determine which variable to bind to for notification offset
+  // Normal reminders use temporaryNotificationTime field, recurring reminders use notifOffsetTimeMin
+  function getNotificationOffset(reminder: UIReminder): number | null {
+    // If reminder is recurring, bind to notifOffsetTimeMin
+    if (reminder.recurrence) {
+      if (reminder.recurrence.type === 'daily' && reminder.recurrence.daily) {
+        return reminder.recurrence.daily.notifOffsetTimeMin ?? null;
+      }
+      else if (reminder.recurrence.type === 'weekly' && reminder.recurrence.weekly) {
+        return reminder.recurrence.weekly.notifOffsetTimeMin ?? null;
+      }
+      else if (reminder.recurrence.type === 'monthly' && reminder.recurrence.monthly) {
+        return reminder.recurrence.monthly.notifOffsetTimeMin ?? null;
+      }
+      else if (reminder.recurrence.type === 'yearly' && reminder.recurrence.yearly) {
+        return reminder.recurrence.yearly.notifOffsetTimeMin ?? null;
+      }
+      // For any other recurrence type, return null (should not get here)
+      return null;
+    }
+    else {
+      // If reminder is not recurring, bind to temporaryNotificationTime
+      return reminder.temporaryNotificationTime ?? null;
+    }
+  }
+
+  // When user changes notification offset dropdown (val), update the correct field in the reminder
+  function setNotificationOffset(reminder: UIReminder, val: number| null) {
+    // If reminder is recurring, update notifOffsetTimeMin feidl to updated value
+    if (reminder.recurrence) {
+      if (reminder.recurrence.type === 'daily' && reminder.recurrence.daily) {
+        reminder.recurrence.daily.notifOffsetTimeMin = val;
+      }
+      else if (reminder.recurrence.type === 'weekly' && reminder.recurrence.weekly) {
+        reminder.recurrence.weekly.notifOffsetTimeMin = val;
+      }
+      else if (reminder.recurrence.type === 'monthly' && reminder.recurrence.monthly) {
+        reminder.recurrence.monthly.notifOffsetTimeMin = val;
+      }
+      else if (reminder.recurrence.type === 'yearly' && reminder.recurrence.yearly) {
+        reminder.recurrence.yearly.notifOffsetTimeMin = val;
+      }
+    } else {
+      // If reminder is not recurring, update temporaryNotificationTime field to updated value
+      reminder.temporaryNotificationTime = val;
+    }
+  }
 
 // Array of notes
 const notes = ref<UINote[]>([])
@@ -2152,43 +2201,6 @@ async function saveNote(note: UINote){
   }
 }
 
-// Function to limit event duration by recurrence type to prevent overlaps
-// Ex. Daily reminders cant be more than 1 day, weekly more than a week, etc.
-function getRecurrenceEventDuration(recurrenceType: string): number {
-  switch (recurrenceType) {
-    case 'daily': {
-      // Number of minutes in a day (24 hrs a day * 60 min an hr = 1140 min max)
-      // event duration cannot exceed more than 1 day (24 hours) for a daily recurring reminder
-      return 1140;
-    }
-
-    case 'weekly': {
-      // Number of minutes in a week (7 days * 24 hrs a day * 60 min an hr = 10080 min max)
-      // event duration cannot exceed more than 1 week/7 days for a weekly recurring reminder
-      return 10080;
-    }
-
-    case 'monthly': {
-      // Number of minutes in a month (28 days * 24 hrs a day * 60 min an hr = 40320 min max)
-      // event duration cannot exceed more than 1 month/28 days for a monthly recurring reminder
-      // Using 28 days for safety because using 31 days can be dangerous for a month with less (it will overlap)
-      return 40320;
-    }
-
-    case 'yearly': {
-      // Number of minutes in a year (365 days * 24 hrs a day * 60 min an hr = 525600 min max)
-      // event duration cannot exceed more than 1 year/365 days for yearly recurring reminder
-      // Using 365 days (not 366 for leap) for safety
-      return 525600;
-    }
-
-    // If nothing else matches, use daily (within a day)
-    default: {
-      return 1440;
-    }
-  }
-}
-
 // Function to validate and save recurring reminder when save button is clicked
 // Returns true if successful (passed validation and saved DB entry), false if not
 async function saveRecurringReminder(reminder: UIReminder) {
@@ -2231,10 +2243,9 @@ async function saveRecurringReminder(reminder: UIReminder) {
       return false;
     }
 
-    // Daily reminder cannot be more than a day
-    const maxDailyDuration = getRecurrenceEventDuration('daily');
-    if (eventDurationMin > maxDailyDuration) {
-      reminder.timeMessageError = 'Daily reminder cannot last more than a day.';
+    // Event duration cannot be more than a day
+    if (eventDurationMin > 1440) {
+      reminder.timeMessageError = 'Event duration cannot be more than a day.';
       return false;
     }
 
@@ -2261,6 +2272,18 @@ async function saveRecurringReminder(reminder: UIReminder) {
       reminder.timeMessageError = 'Start time must be before end time.';
       return false;
     }
+
+  // Check that frequency (everyNDays) fits in the series range
+  // Prevents recurring series that make no generated reminders (ex. series range is 2 days but frequency is every 3 days)
+  // Convert ms in time (epoch) to number of days in the series range
+  const msPerDay = 1000 * 60 * 60 * 24;
+  // Add 1 to include start and end date in the series length
+  const seriesLength = Math.floor((endEpoch - startEpoch) / msPerDay) + 1;
+
+  if (reminder.recurrence.daily.everyNDays > seriesLength) {
+    reminder.timeMessageError = 'Frequency must fit within series length.';
+    return false;
+  }
 
     // Make sure recurring reminder is saved in preexisting folder
   if (reminder.temporaryFolderID == null || !folders.value.some(folder => String(folder.folderID) === String(reminder.temporaryFolderID))) {
@@ -2327,6 +2350,7 @@ async function saveRecurringReminder(reminder: UIReminder) {
       else {
       // Create new series reminder
       const seriesID = await createDailyReminder(reminder.temporaryFolderID, reminder.eventType, seriesStartTime, seriesEndTime, timeOfDayMin, eventDurationMin, recurringNotifOffset, hasNotification, everyNDays, reminder.temporaryTitle, extensionsToSend);
+      // Delete old normal reminder
       await deleteItem(reminder.itemID, 12);
       const row = await readDailyReminder(seriesID);
        // Map recurring reminder to UI format

--- a/client/src/pages/CalendarPage.vue
+++ b/client/src/pages/CalendarPage.vue
@@ -1,7 +1,7 @@
 <!--
  * Authors: Rachel Patella, Maria Pasaylo, Michael Jagiello
  * Created: 2025-09-22
- * Updated: 2025-11-24
+ * Updated: 2025-11-25
  *
  * This file is the main home page that includes the calendar view, notes/reminders list, 
  * and a file explorer as a 3 column grid layout.
@@ -180,7 +180,21 @@
           </template>
         </q-tree>
         <div style="display: flex; flex-wrap: wrap; align-items: center; margin-top: auto; gap: 4px;">
-          <q-btn style="font-size: 0.9rem; color: #474747;" flat  icon="add"  label="Add" @click="addFolder()" />
+          <q-btn style="font-size: 0.9rem; color: #474747;" flat  icon="add"  label="Add">
+          <q-menu>
+          <q-list style="min-width: 100px">
+            <q-item @click= addExplorerReminder(); clickable v-close-popup>
+              <q-item-section>Reminder</q-item-section>
+            </q-item>
+            <q-item @click = addExplorerNote(); clickable v-close-popup>
+              <q-item-section>Note</q-item-section>
+            </q-item>
+              <q-item @click= addFolder(); clickable v-close-popup>
+              <q-item-section>Folder</q-item-section>
+            </q-item>
+            </q-list>
+          </q-menu>
+        </q-btn>
           <q-btn style="font-size: 0.9rem; color: #474747;" flat  icon="delete"  label="Delete" @click="deleteTreeNode()" />
           <q-btn style="font-size: 0.9rem; color: #474747;" flat  icon="edit"  label="Rename" @click="renameTreeNode()" />
         </div>
@@ -616,6 +630,8 @@
                     class="flight-half"
                     maxlength="3"
                   />
+                  <!--Extension times are only shown for normal/generated reminders, recurring uses tiemOfDayMin and eventDuration -->
+                  <template v-if="!item.isRecurring && !item.isGenerated">
                   <q-input
                     v-model="item.extension.depTime"
                     label="Departure Time"
@@ -632,6 +648,25 @@
                     dense
                     class="flight-half"
                   />
+                  </template>
+                  <template v-if="item.isGenerated">
+                  <q-input
+                  v-model="item.temporaryEventStartTime"
+                  label="Departure Time"
+                  type="time"
+                  outlined
+                  dense
+                  class="flight-half"
+                  />
+                  <q-input
+                  v-model="item.temporaryEventEndTime"
+                  label="Arrival Time"
+                  type="time"
+                  outlined
+                  dense
+                  class="flight-half"
+                  />
+                  </template>
                   <div v-if="item.temporaryEventEndDateEnabled" style="width:100%; grid-column: 1 / -1;">
                     <q-input
                       v-model="item.temporaryEventEndDay"
@@ -741,6 +776,7 @@
                 class="flight-full"
                 maxlength="10"
                 />
+                <template v-if="!item.isRecurring && !item.isGenerated">
                 <q-input 
                 v-model="item.extension.checkinTime" 
                 label="Check-in time" 
@@ -757,6 +793,25 @@
                 dense 
                 class="flight-half"
                 />
+                </template>
+                <template v-if="item.isGenerated">
+                <q-input
+                v-model="item.temporaryEventStartTime"
+                label="Check-in Time"
+                type="time"
+                outlined
+                dense
+                class="flight-half"
+                />
+                <q-input
+                v-model="item.temporaryEventEndTime"
+                label="Check-out Time"
+                type="time"
+                outlined
+                dense
+                class="flight-half"
+                />
+                </template>
                 <div v-if="item.temporaryEventEndDateEnabled" style="width:100%; grid-column: 1 / -1;">
                   <q-input
                     outlined
@@ -818,7 +873,7 @@
               </div>
                 <div class="row" style="display:flex; flex-wrap:wrap; align-items:center">
                   <q-btn class="login-register-button" style="font-size: 15px; margin-right: 10px" flat label="Save" @click="saveReminder(item)"></q-btn>
-                  <q-btn class="login-register-button" style="background-color: grey; font-size: 15px" flat label="Cancel" @click="cancelReminder(item)"></q-btn>
+                  <q-btn v-if="!item.isGenerated" class="login-register-button" style="background-color: grey; font-size: 15px" flat label="Cancel" @click="cancelReminder(item)"></q-btn>
                   <q-btn v-if="item.isGenerated" class="login-register-button" style="font-size: 15px" flat label="View Series" @click="showParentSeriesFromGeneratedReminder(item)"></q-btn>
                   <q-btn v-if="item.isRecurring && previousListState && String(previousListState.parentSeriesID) === String(item.itemID)" class="login-register-button" style="background-color: grey; font-size: 15px" flat label="View Generated" @click="showGeneratedReminderFromParentSeries()"></q-btn>
                 </div>
@@ -880,7 +935,7 @@
     <div style="grid-area: calendar; padding: 20px" data-area="calendar">
       <div style="display: flex; justify-content: center">
         <div style="
-            max-width: 400px;
+            max-width: 500px;
             width: 100%;
             display: flex;
             flex-direction: column;
@@ -903,17 +958,17 @@
             </div>
           </div>
           <div style="display: flex; justify-content: center; align-items: center;">
-            <div style="display: flex; max-width: 500px; width: 100%; flex-direction: column;"> 
+            <div style="display: flex; max-width: 600px; width: 100%; flex-direction: column;"> 
               <q-calendar-month ref="calendar" v-model="selectedDate" mini-mode hoverable focusable
-                :focus-type="['date', 'weekday']" :min-weeks="6" animated @change="onChange" @moved="onMoved"
+                :focus-type="['date', 'weekday']" :min-weeks="6" animated 
                 @click-date="onClickDate" @click-day="onClickDay" @click-workweek="onClickWorkweek"
                 @click-head-workweek="onClickHeadWorkweek" @click-head-day="onClickHeadDay" style="height: 400px;" >
                 <template #day="{ scope: { timestamp } }">
-                <div style="display: flex; flex-direction: column; gap: 3px; padding: 2px; align-items: center; justify-content: center;">
+                <div style="display: flex; flex-direction: row; gap: 3px; padding: 2px; align-items: center; justify-content: center; overflow:hidden; max-height: 24px;">
               <template v-for="event in eventsMap[timestamp.date]" :key="String(event.id)">
                 <div
                 :class="`bg-${event.color}`"
-                style="width: 8px; height: 8px; border-radius: 50%; cursor: pointer;"
+                style="width: 8px; height: 8px; border-radius: 50%; cursor: pointer; flex-shrink: 0;"
                 @click="onClickCalendarEvent(event)"
               >
                 <!-- Tooltip on hover to clarify if event start or end -->
@@ -992,11 +1047,11 @@ const filteredReminders = computed(() => {
   // Search functionality example: https://stackoverflow.com/questions/74670957/how-to-display-search-results-using-react-typescript
   const query = (searchQuery.value ?? '').trim().toLowerCase();
 
-  // By default, middle list only shows normal reminders and recurring drafts (or saved reminders being converted to recurring)
+  // By default, middle list only shows normal reminders, generated reminders, and recurring drafts (or saved reminders being converted to recurring)
   const defaultReminderList = reminders.value.filter(reminder => !reminder.isRecurring || !reminder.isSaved || reminder.isConverting);
 
  // No search query, either show recurring reminder if selected on file explorer
- // Or show default list otherwise (normal reminders and recurring drafts)
+ // Or show default list otherwise (normal reminders, generated reminders, and recurring drafts)
   if (!searchQuery.value) {
     if (selectedFolderID.value !== null && selectedFolderID.value < 0n) {
       const selectedNode = -selectedFolderID.value;
@@ -1011,7 +1066,7 @@ const filteredReminders = computed(() => {
     }
   }
 
-  // Otherwise, if search query is provided, only search normal reminders and recurring drafts (default list) by title
+  // Otherwise, if search query is provided, only search normal reminders, generated reminders, and recurring drafts (default list) by title
   return defaultReminderList.filter(reminder => {
     // Check for reminders entries where the title is in the search query
     const matchesQuery = String(reminder.temporaryTitle ?? '').toLowerCase().includes(query) || String(reminder.title ?? '').toLowerCase().includes(query);
@@ -1270,7 +1325,43 @@ const eventTypes: EventType[] = [
       }
     }
 
-    // Check if arrTime or checkOut time exist
+    // If reminder is recurring and field is empty (intended as times are hidden), use recurrence timeOfDayMin (Start/Departure/Check-in time) and eventDuration (to compute End/Arrival/Check-out time)
+    if (reminder.isRecurring && reminder.recurrence) {
+     let minOfDay: number = 0;
+     let eventDuration: number = 0;
+
+     if (reminder.recurrence.type === 'daily' && reminder.recurrence.daily) {
+      minOfDay = reminder.recurrence.daily.timeOfDayMin;
+      eventDuration = reminder.recurrence.daily.eventDurationMin;
+     }
+     else if (reminder.recurrence.type === 'weekly' && reminder.recurrence.weekly) {
+      minOfDay = reminder.recurrence.weekly.timeOfDayMin;
+      eventDuration = reminder.recurrence.weekly.eventDurationMin;
+     }
+     else if (reminder.recurrence.type === 'monthly' && reminder.recurrence.monthly) {
+      minOfDay = reminder.recurrence.monthly.timeOfDayMin;
+      eventDuration = reminder.recurrence.monthly.eventDurationMin;
+     }
+     else if (reminder.recurrence.type === 'yearly' && reminder.recurrence.yearly) {
+      minOfDay = reminder.recurrence.yearly.timeOfDayMin;
+      eventDuration = reminder.recurrence.yearly.eventDurationMin;
+     }
+     // Convert timeOfDayMin from a number to a HH:MM string
+     const startString = minutesToHHMM(minOfDay);
+     // Compute end time from start time + event duration
+     const endMin = (minOfDay + eventDuration) % 1440;
+     const endString = minutesToHHMM(endMin);
+     // Set extension times to start and end recurrence times if the fields exist
+     if (fieldKey === 'depTime' || fieldKey === 'checkinTime') {
+      return convertTimeAndDateToTimestamp(reminder.date, startString) ?? undefined;
+     }
+     else if (fieldKey === 'arrTime' || fieldKey === 'checkoutTime') {
+      // Use event end day for multi-day events and event start day for single day events
+      return convertTimeAndDateToTimestamp(eventEndDay, endString) ?? undefined;
+     }
+    }
+        
+    // Check if arrTime or checkOut time exist and reminder is normal/non-recurring
     if (fieldKey === 'arrTime' || fieldKey === 'checkoutTime') {
       // If arrival time (end) is the key field, see if departure time (start) exists in record
       // Otherwise if check out time (end) is the key field, see if check in time (start) exists in record
@@ -1330,7 +1421,6 @@ const eventTypes: EventType[] = [
 
       // Fields are provided and validated, build extension to save
       const exts = FlightToExtensions(flightFields) ?? [];
-      // console.log('PACKER final packed extensions (to be saved):', exts);
       return exts;
     }
       // Hotel
@@ -1397,11 +1487,10 @@ async function onToggleCloudSync() {
   try {
     await window.syncAPI.sync();
     syncStatusMessage.value = 'Cloud Synced Successfully';
-    console.log('Cloud sync completed successfully');
   } catch (error) {
     syncStatusMessage.value = 'Cloud Sync Failed';
     console.error('Error during cloud sync:', error);
-   // Incase of error, reset sync status
+   // Reset sync status for next time
   } finally {
     isSyncing.value = false;
   }
@@ -1695,7 +1784,7 @@ function cancelRename(item: UIReminder | UINote | UIFolder) {
   // Distinguish between folder and reminder/note by checking for unique property
   // Cancel renaming a folder
   if ('temporaryFolderName' in item) {
-    // Folder is a draft, remove from UI
+    // Folder is a draft, remove from UI and keep all other entries
     if (!item.isSaved) {
       folders.value = folders.value.filter(f => String(f.folderID) !== String(item.folderID));
       // Clear tree node selection
@@ -1796,15 +1885,15 @@ async function loadRemindersForCalendarDate(dateString: string) {
   const endOfDay = convertTimeAndDateToTimestamp(dateString, '23:59');
 
   try {
-    // Filter out any reminders already in list for that date to avoid duplicates
-    reminders.value = reminders.value.filter(reminder => reminder.isRecurring || reminder.date !== dateString);
+    // Filter out any normal reminders already in list for that date before loading from database to avoid duplicate display
+    // Therefore, remove any normal reminders and keep recurring and generated
+    reminders.value = reminders.value.filter(reminder => reminder.isRecurring || reminder.isGenerated || reminder.date !== dateString);
     // Read reminders for currently selected date from local DB
     const rows = await readRemindersInRange(startOfDay, endOfDay);
     // Convert each reminder in range from response to UI reminder format 
     for (const reminder of rows) {
       mapDBToUIReminder(reminder, true);
     }
-    // console.log('Reminders for date loaded successfully:');
   } catch (error) {
     console.error('Error loading reminders for date:', error);
   }
@@ -1850,8 +1939,8 @@ async function loadRemindersForMonth(dateString: string) {
   const endRange = convertTimeAndDateToTimestamp(lastDayString, '23:59');
 
   try {
-    // Reload monthReminders for calendar 
-    monthReminders.value = [];
+    // Clear normal reminders before loading from database for calendar, keep generated reminders
+    monthReminders.value = monthReminders.value.filter(reminder => reminder.isGenerated);
     const rows = await readRemindersInRange(startRange, endRange);
     const requestedYM = `${String(year).padStart(4,'0')}-${String(month).padStart(2,'0')}`;
     // Convert each reminder in range from response to UI reminder format 
@@ -1863,7 +1952,6 @@ async function loadRemindersForMonth(dateString: string) {
           // push into monthReminders so the calendar uses these events
           monthReminders.value.push(result);
         }
-        // console.log('Reminders for month successfully loaded:');
       }
     } catch (error) {
     console.error('Error loading reminders for month:', error);
@@ -1920,13 +2008,13 @@ async function loadGeneratedReminders(dateString: string) {
   const nextMonthEndRange = convertTimeAndDateToTimestamp(nextMonthLastDayString, '23:59');
 
   try {
-    // Clear existing generated reminders before reloading to avoid duplicates
+    // Clear existing generated reminders before reloading fresh ones from database to avoid duplicate display
+    // Therefore, keep items that are not generated and filter out generated ones
     reminders.value = reminders.value.filter(reminder => !reminder.isGenerated);
     monthReminders.value = monthReminders.value.filter(reminder => !reminder.isGenerated);
 
     // Read the viewable calendar month
     const currentMonthReminders = await readGeneratedRemindersInRange(startRange, endRange);
-    //console.log('Current month generated reminders from DB:', currentMonthReminders.length, currentMonthReminders); // DEBUG
     // Convert each generated reminder in range from response to UI reminder format 
     for (const generatedReminder of currentMonthReminders) {
       // Map to UI and push to middle list (reminders array)
@@ -1937,7 +2025,6 @@ async function loadGeneratedReminders(dateString: string) {
 
     // Read the next month after
     const nextMonthReminders = await readGeneratedRemindersInRange(nextMonthStartRange, nextMonthEndRange);
-    //console.log('Next month generated reminders from DB:', nextMonthReminders.length, nextMonthReminders); // DEBUG
     // Convert each generated reminder in range from response to UI reminder format
     for (const generatedReminder of nextMonthReminders) {
       // Map to UI and push to middle list (reminders array)
@@ -1968,7 +2055,6 @@ async function loadReminders(year?: number) {
     }
     // sort reminders alphabetically by title for tree 
     reminders.value.sort((a, b) => {return String(a.temporaryTitle ?? a.title ?? '').toLowerCase().localeCompare(String(b.temporaryTitle ?? b.title ?? '').toLowerCase());});
-    // console.log('All reminders loaded successfully:');
   } catch (error) {
     console.error('Error loading reminders:', error);
   }
@@ -2054,13 +2140,11 @@ async function addRootFolder() {
     const hasRootFolder = folders.some(folder => folder.parentFolderID === -1n || folder.folderID === 0n);
     if (!hasRootFolder) {
       await createRootFolder(-1);
-      console.log('Root folder created.', folders);
       // Refresh folder list after creating root folder
       await readAllFolders();
     }
     else {
       // Root folder already exists
-      //console.log('Root folder already exists.');
     }
   }
   catch (error) {
@@ -2142,7 +2226,6 @@ function mapDBToUIReminder(row: Reminder, upsert: boolean): UIReminder {
     // If a flight, extract flight fields
     if (row.eventType === 1) {
       const flightFields = ExtensionsToFlight(extensionsArr);
-      console.log('flightFields', flightFields, 'extensionsUI', extensionsUI);
       if (flightFields) {
         extensionsUI.depAirportName = stripNulls(flightFields.depAirportName ?? '');
         extensionsUI.depAirportAddress = stripNulls(flightFields.depAirportAddress ?? '');
@@ -2299,7 +2382,6 @@ function mapDBGeneratedToUIReminder(row: GeneratedReminder, upsert: boolean): UI
     // If a flight, extract flight fields
     if (row.eventType === 1) {
       const flightFields = ExtensionsToFlight(extensionsArr);
-      console.log('flightFields', flightFields, 'extensionsUI', extensionsUI);
       if (flightFields) {
         extensionsUI.depAirportName = stripNulls(flightFields.depAirportName ?? '');
         extensionsUI.depAirportAddress = stripNulls(flightFields.depAirportAddress ?? '');
@@ -2537,8 +2619,7 @@ function mapDBSeriesToUIRecurringReminder(row: DailyReminder | WeeklyReminder | 
   if (extensionsArr && extensionsArr.length > 0) {
     // If a flight, extract flight fields
     if (row.eventType === 1) {
-      const flightFields = ExtensionsToFlight(extensionsArr);
-      console.log('flightFields', flightFields, 'extensionsUI', extensionsUI);
+      const flightFields = ExtensionsToFlight(extensionsArr);;
       if (flightFields) {
         extensionsUI.depAirportName = stripNulls(flightFields.depAirportName ?? '');
         extensionsUI.depAirportAddress = stripNulls(flightFields.depAirportAddress ?? '');
@@ -2848,7 +2929,6 @@ async function saveNote(note: UINote){
  try {
   if (!note.isSaved) {
     const itemID = await createNote(note.temporaryFolderID, note.temporaryTitle, note.temporaryText);
-    console.log('Note successfully created:', itemID);
 
     // Give this new note the actual itemID assigned by the DB and mark it saved so future saves go to update
     note.itemID = itemID;
@@ -2865,7 +2945,6 @@ async function saveNote(note: UINote){
   }
   else {
       await updateNote(note.itemID, note.temporaryFolderID, note.temporaryTitle, note.temporaryText);
-      console.log('Note successfully updated:', note.itemID);
 
       // Map DB row into UI and update notes.value array
       const row = await readNote(note.itemID); 
@@ -2896,6 +2975,15 @@ async function saveRecurringReminder(reminder: UIReminder) {
   if (!reminder.recurrence || !reminder.isRecurring) {
     return false;
   }
+
+    // Clear extension fields for recurring series to ensure the times are built off recurrence rules (in case reminder was normal before)
+    reminder.extension = reminder.extension ?? {};
+    ['depTime','arrTime','checkinTime','checkoutTime','boardingTime'].forEach(fieldKey => {
+      if (fieldKey in reminder.extension) {
+        // Null will cause it to go to the recurrence check in buildExtensionsForEventType
+        reminder.extension[fieldKey] = null;
+      }
+    });
 
   // Build event type extensions from UI fields
   const extensions = buildExtensionsForEventType(reminder);
@@ -3062,7 +3150,7 @@ async function saveDailyReminder(reminder: UIReminder, extensionsToSend: Extensi
         mapDBSeriesToUIRecurringReminder(row, 'daily', true);
       }
 
-      // Remove old normal reminder from UI
+      // Remove old normal reminder from UI, keep all other entries
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
 
       // Reload generated reminders after new series creation to immediately show new items
@@ -3219,7 +3307,7 @@ async function saveWeeklyReminder(reminder: UIReminder, extensionsToSend: Extens
         mapDBSeriesToUIRecurringReminder(row, 'weekly', true);
       }
 
-      // Remove old normal reminder from UI
+      // Remove old normal reminder from UI, keep all other entries
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
 
       // Reload generated reminders after new series creation to immediately show new items
@@ -3373,7 +3461,7 @@ async function saveMonthlyReminder(reminder: UIReminder, extensionsToSend: Exten
         mapDBSeriesToUIRecurringReminder(row, 'monthly', true);
       }
 
-      // Remove old normal reminder from UI list
+      // Remove old normal reminder from UI, keep all other entries
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
 
       // Reload generated reminders after new series creation to immediately show new items
@@ -3503,7 +3591,7 @@ async function saveYearlyReminder(reminder: UIReminder, extensionsToSend: Extens
         mapDBSeriesToUIRecurringReminder(row, 'yearly', true);
       }
 
-      // Remove old normal reminder from UI list
+      // Remove old normal reminder from UI, keep all other entries
       reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
 
       // Reload generated reminders after new series creation to immediately show new items
@@ -3685,13 +3773,12 @@ try {
   const extensionsToSend = (extensions && extensions.length > 0) ? extensions : undefined;
   // Reminder is not yet saved (first time saving after clicking add), create reminder in DB
   if (!reminder.isSaved) {
-  //console.log('Saving reminder extensions:', extensions);
+
   // Create base reminder in local DB and retrieve the itemID assigned to it
   const itemID = await createReminder(reminder.temporaryFolderID, reminder.eventType, eventStartTime, eventEnd, notificationTimestampToSend, hasNotification, reminder.temporaryTitle, extensionsToSend);
 
   // Fetch the newly created reminder from the DB 
   const row = await readReminder(itemID);
-  // console.log('Read reminder extensions: readReminder row.extensions =', row?.extensions);
   
   // Map DB row into UI and update reminders.value array
   if (row) {
@@ -3728,6 +3815,8 @@ try {
           const itemID = await createReminder(reminder.temporaryFolderID, reminder.eventType, eventStartTime, eventEnd, notificationTimestampToSend, hasNotification, reminder.temporaryTitle, extensionsToSend);
           // Delete the recurring series (also deletes generated reminders)
           await deleteItem(reminder.itemID, tableID);
+          // Remove old series reminder from UI, keep all other entries
+          reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
           // Fetch the newly created reminder from the DB 
           const row = await readReminder(itemID);
   
@@ -3741,10 +3830,12 @@ try {
 
       // Reload calendar month to include newly added reminder
       await loadRemindersForMonth(selectedDate.value);
+
+      // Reload generated reminders since old series was deleted
+      await loadGeneratedReminders(selectedDate.value);
     }
       // Reminder is a normal reminder, just update it in DB
       await updateReminder(reminder.itemID, reminder.temporaryFolderID, reminder.eventType, eventStartTime, eventEnd, notificationTimestampToSend, hasNotification, reminder.temporaryTitle, extensionsToSend);
-      console.log('Reminder updated successfully in DB.');
 
       // Fetch the newly created reminder from the DB 
       const row = await readReminder(reminder.itemID);
@@ -3805,12 +3896,16 @@ async function saveGeneratedReminder(generatedReminder: UIReminder) {
 // Function to delete selected individual checkbox reminders
 async function deleteReminder(reminder: UIReminder) {
   try {
+    // Checkbox deleting a draft removes it from UI and refreshes view
+    if (!reminder.isSaved) {  
+      // Remove draft reminder from UI
+      reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+      return;
+    }
     // Delete specific reminder from local DB
     await deleteItem(reminder.itemID, 12);
-    // Update reminders array to filter out deleted reminder
-    // Array only contains reminders where the itemID does not match the deleted reminder's itemID
-    reminders.value = reminders.value.filter(r => r.itemID !== reminder.itemID);
-    console.log('Reminder deleted successfully from DB.');
+    // Remove old reminder from UI, keep all other entries
+    reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
     // Refresh folders for tree to remove deleted reminder
     folders.value = mapDBToUIFolder(await readAllFolders());
     // Reload reminders for calendar date after deleted reminder
@@ -3829,6 +3924,13 @@ async function deleteReminder(reminder: UIReminder) {
 // Function to delete selected recurring reminders
 async function deleteRecurringReminderSeries(reminder: UIReminder) {
   try {
+    // Checkbox deleting a draft removes it from UI and refreshes view
+    if (!reminder.isSaved) {  
+      // Remove draft reminder from UI, keep all other entries
+      reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
+      return;
+    }
+
     // Validate that the reminder is recurring
     if (!reminder.recurrence || !reminder.isRecurring) {
       console.error('Reminder is not recurring:', reminder.itemID);
@@ -3856,7 +3958,7 @@ async function deleteRecurringReminderSeries(reminder: UIReminder) {
    }
     // Update reminders array to filter out deleted reminder
     // Array only contains reminders where the itemID does not match the deleted reminder's itemID
-    reminders.value = reminders.value.filter(r => r.itemID !== reminder.itemID);
+    reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
    // Successful deletion, refresh file explorer
    folders.value = mapDBToUIFolder(await readAllFolders());
   } catch (error) {
@@ -3868,12 +3970,17 @@ async function deleteRecurringReminderSeries(reminder: UIReminder) {
 // Function to delete selected individual checkbox notes
 async function deleteNote(note: UINote) {
   try {
+    // Checkbox deleting a draft removes it from UI and refreshes view
+    if (!note.isSaved) {  
+      // Remove draft note from UI, keep all other entries
+      notes.value = notes.value.filter(r => String(r.itemID) !== String(note.itemID));
+      return;
+    }
     // Delete specific note from local DB
     await deleteItem(note.itemID, 11);
     // Update notes array to filter out deleted note
     // Array only contains notes where the itemID does not match the deleted note's itemID
     notes.value = notes.value.filter(n => n.itemID !== note.itemID);
-    console.log('Note deleted successfully from DB.');
     // Refresh folders for tree to remove deleted note
     folders.value = mapDBToUIFolder(await readAllFolders());
     // Re-load notes after deleted note
@@ -3957,16 +4064,25 @@ async function deleteTreeNode() {
     const reminderToDelete = reminders.value.find(reminder => String(reminder.itemID) === String(itemID));
     if (reminderToDelete) {
       try {
-        // Delete specific selected reminder from DB and refresh UI
-        await deleteItem(reminderToDelete.itemID, 12);
-        // Remove deleted reminder from reminders array for UI rendering
-        reminders.value = reminders.value.filter(reminder => String(reminder.itemID) !== String(reminderToDelete.itemID));
-        folders.value = mapDBToUIFolder(await readAllFolders());
-        await loadRemindersForCalendarDate(selectedDate.value);
-        // Delete from calendar
-        await loadRemindersForMonth(selectedDate.value);
-        // Clear tree node selection after deletion
-        selectedFolderID.value = null;
+        if (reminderToDelete.isRecurring) {
+          // If reminder is recurring, delete series and reload generated
+          await deleteRecurringReminderSeries(reminderToDelete);
+          // Clear tree node selection after deletion
+          selectedFolderID.value = null;
+          return;
+        }
+        else {
+          // Delete specific selected reminder from DB and refresh UI
+          await deleteItem(reminderToDelete.itemID, 12);
+          // Remove deleted reminder from reminders array for UI rendering
+          reminders.value = reminders.value.filter(reminder => String(reminder.itemID) !== String(reminderToDelete.itemID));
+          folders.value = mapDBToUIFolder(await readAllFolders());
+          await loadRemindersForCalendarDate(selectedDate.value);
+          // Delete from calendar
+          await loadRemindersForMonth(selectedDate.value);
+          // Clear tree node selection after deletion
+          selectedFolderID.value = null;
+        }
       } catch (error) {
         console.error('Error deleting reminder from DB:', error);
       }
@@ -3982,6 +4098,18 @@ async function addArrayItem() {
   } else if (tab.value === 'notes') {
     addNote();
   }
+}
+
+// Adds a new reminder draft from the file explorer add button
+function addExplorerReminder() {
+  tab.value = 'reminders';
+  addReminder();
+}
+
+// Adds a new note draft from the file explorer add button
+function addExplorerNote() {
+  tab.value = 'notes';
+  addNote();
 }
 
 // Toggles behavior of delete button. If on reminder tab, delete selected reminders from array. If on notes tab, delete selected notes from array.
@@ -4008,11 +4136,14 @@ async function deleteArrayItem() {
 
 // Reverts fields back to stored values from DB for a reminder when cancel button is clicked or remove draft
 async function cancelReminder(reminder: UIReminder) {
+  // No generated support for canceling (no function exists to read a single generated by ID because they share itemID with the parent series)
+  if (reminder && reminder.isGenerated) {
+    return;
+  }
   // Reminder is a draft, remove from list
   if (!reminder.isSaved) {
     reminders.value = reminders.value.filter(r => String(r.itemID) !== String(reminder.itemID));
-    // Reload list for selected calendar date
-    await loadRemindersForCalendarDate(selectedDate.value);
+    return;
   // Reminder is saved, revert temporary fields back to saved database values
   } else {
       // Reminder is recurring, cancel its fields back to saved DB state
@@ -4119,6 +4250,7 @@ watch(selectAll, (selectionVal) => {
 watch(selectedDate, async (newDate) => {
   // Load reminders for newly selected calendar date
   await loadRemindersForCalendarDate(newDate);
+  await loadRemindersForMonth(newDate);
   await loadGeneratedReminders(newDate);
 });
 
@@ -4180,16 +4312,14 @@ function onNext() {
 }
 
 // Show reminders for current calendar month
-async function onMoved(data: Timestamp) {
-  console.log('qcalendar onMoved payload:', data);
-  await loadRemindersForMonth(selectedDate.value);
-  await loadGeneratedReminders(selectedDate.value);
-}
-async function onChange(data: Timestamp) {
-  console.log('qcalendar onChange payload:', data);
-  await loadRemindersForMonth(selectedDate.value);
-  await loadGeneratedReminders(selectedDate.value);
-}
+//async function onMoved(data: Timestamp) {
+ // await loadRemindersForMonth(selectedDate.value);
+ //await loadGeneratedReminders(selectedDate.value);
+//}
+//async function onChange(data: Timestamp) {
+ // await loadRemindersForMonth(selectedDate.value);
+ // await loadGeneratedReminders(selectedDate.value);
+//}
 
 function onClickDate(data: Timestamp) {
   console.info('onClickDate', data)

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -2,7 +2,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-21
- * Updated: 2025-11-16
+ * Updated: 2025-11-17
  *
  * This file contains interfaces that extend the shared-types with UI-specific fields.
  *
@@ -68,8 +68,9 @@ export type recurrenceReminder = {
   yearly?: yearlyReminder;
 };
 
+// Frontend treats these fields as strings when binding v-model, will be converted to number when performing DB operations
 export type dailyReminder = {
-  timeOfDayMin: string;
+  timeOfDayMin: number;
   eventDurationMin: number;
   notifOffsetTimeMin: number | null;
   everyNDays: number;
@@ -86,7 +87,7 @@ export type weeklyReminder = {
 };
 
 export type monthlyReminder = {
-  timeOfDayMin: string;
+  timeOfDayMin: number;
   eventDurationMin: number;
   notifOffsetTimeMin: number | null;
   lastDayOfMonth: boolean;
@@ -95,7 +96,7 @@ export type monthlyReminder = {
 };
 
 export type yearlyReminder = {
-  timeOfDayMin: string;
+  timeOfDayMin: number;
   eventDurationMin: number;
   notifOffsetTimeMin: number | null;
   dayOfYear: number;

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Note, Reminder, Folder } from '../../src-electron/types/shared-types'; 
+import { type Timestamp } from '@quasar/quasar-ui-qcalendar';
 
 // UI types extend client backend/shared-types model with UI-only fields for use in renderer
 // Some fields can change in the UI (ex. folderID null until user selects a folder), but are set in stone for backend DB
@@ -58,6 +59,8 @@ export type UIReminder = Reminder & {
   // Used to see saved reminder in list while user toggles recurrence
   isConverting: boolean;
   isGenerated: boolean;
+  // Used in overrides to track original timestamp
+  originalGeneratedTimestamp: Timestamp | null;
   // Parent recurring series ID for generated instances
   linkedParentSeriesID: bigint | null;
   // Carat open/close                                                       

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -2,7 +2,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-21
- * Updated: 2025-11-21
+ * Updated: 2025-11-23
  *
  * This file contains interfaces that extend the shared-types with UI-specific fields.
  *
@@ -102,7 +102,7 @@ export type yearlyReminder = {
   timeOfDayMin: number;
   eventDurationMin: number;
   notifOffsetTimeMin: number | null;
-  dayOfYear: number;
+  dayOfYear: string;
   seriesEndDate: string;
 };
 

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -73,6 +73,7 @@ export type dailyReminder = {
   eventDurationMin: number;
   notifOffsetTimeMin: number | null;
   everyNDays: number;
+  seriesEndDate: string;
 };
 
 export type weeklyReminder = {
@@ -81,6 +82,7 @@ export type weeklyReminder = {
   notifOffsetTimeMin: number | null;
   everyNWeeks: number;
   daysOfWeek: string;
+  seriesEndDate: string;
 };
 
 export type monthlyReminder = {
@@ -89,6 +91,7 @@ export type monthlyReminder = {
   notifOffsetTimeMin: number | null;
   lastDayOfMonth: boolean;
   daysOfMonth: string;
+  seriesEndDate: string;
 };
 
 export type yearlyReminder = {
@@ -96,6 +99,7 @@ export type yearlyReminder = {
   eventDurationMin: number;
   notifOffsetTimeMin: number | null;
   dayOfYear: number;
+  seriesEndDate: string;
 };
 
 // Shared-types folder has folderID, lastModified, parentFolderID, colorCode, folderName

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -57,6 +57,10 @@ export type UIReminder = Reminder & {
   isSelected: boolean;
   // Used to see saved reminder in list while user toggles recurrence
   isConverting: boolean;
+  isGenerated: boolean;
+  // Parent recurring series ID for generated instances
+  linkedParentSeriesID: bigint | null;
+  // Carat open/close                                                       
   expanded: boolean;
   temporaryEventEndDateEnabled: boolean;
   // UI-only date field - calendar date selected for the reminder

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -2,7 +2,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-21
- * Updated: 2025-11-12
+ * Updated: 2025-11-16
  *
  * This file contains interfaces that extend the shared-types with UI-specific fields.
  *
@@ -47,7 +47,9 @@ export type UIReminder = Reminder & {
   // Extension is always present (may be empty) to avoid undefined checks in UI. Still optional in backend
   extension: Record<string, string | number | null>;  // Essentially extension is a dictionary-like object with keys (ex. field names) and values  
   // useful for adding on custom event type fields/extensions that we may not know the types to yet
-  // Need to parse and store this text data in the separate extensions table in the backend
+  // Reminder recurrence fields to fill out UI form
+  recurrence?: recurrenceReminder | null;
+  isRecurring: boolean;
   isSaved: boolean;
   isEditing: boolean; 
   isSelected: boolean;
@@ -55,6 +57,45 @@ export type UIReminder = Reminder & {
   temporaryEventEndDateEnabled: boolean;
   // UI-only date field - calendar date selected for the reminder
   date: string;
+};
+
+// Recurrence reminder (holds all recurrence reminder types)
+export type recurrenceReminder = {
+  type: string;
+  daily?: dailyReminder;
+  weekly?: weeklyReminder;
+  monthly?: monthlyReminder;
+  yearly?: yearlyReminder;
+};
+
+export type dailyReminder = {
+  timeOfDayMin: string;
+  eventDurationMin: number;
+  notifOffsetTimeMin: number | null;
+  everyNDays: number;
+};
+
+export type weeklyReminder = {
+  timeOfDayMin: number;
+  eventDurationMin: number;
+  notifOffsetTimeMin: number | null;
+  everyNWeeks: number;
+  daysOfWeek: string;
+};
+
+export type monthlyReminder = {
+  timeOfDayMin: string;
+  eventDurationMin: number;
+  notifOffsetTimeMin: number | null;
+  lastDayOfMonth: boolean;
+  daysOfMonth: string;
+};
+
+export type yearlyReminder = {
+  timeOfDayMin: string;
+  eventDurationMin: number;
+  notifOffsetTimeMin: number | null;
+  dayOfYear: number;
 };
 
 // Shared-types folder has folderID, lastModified, parentFolderID, colorCode, folderName

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -2,7 +2,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-21
- * Updated: 2025-11-17
+ * Updated: 2025-11-19
  *
  * This file contains interfaces that extend the shared-types with UI-specific fields.
  *
@@ -49,10 +49,14 @@ export type UIReminder = Reminder & {
   // useful for adding on custom event type fields/extensions that we may not know the types to yet
   // Reminder recurrence fields to fill out UI form
   recurrence?: recurrenceReminder | null;
+  // Used to determine which series table the recurring reminders itemID is from
+  originalRecurrenceType?: string | null;
   isRecurring: boolean;
   isSaved: boolean;
   isEditing: boolean; 
   isSelected: boolean;
+  // Used to see saved reminder in list while user toggles recurrence
+  isConverting: boolean;
   expanded: boolean;
   temporaryEventEndDateEnabled: boolean;
   // UI-only date field - calendar date selected for the reminder
@@ -68,7 +72,6 @@ export type recurrenceReminder = {
   yearly?: yearlyReminder;
 };
 
-// Frontend treats these fields as strings when binding v-model, will be converted to number when performing DB operations
 export type dailyReminder = {
   timeOfDayMin: number;
   eventDurationMin: number;

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -2,7 +2,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-21
- * Updated: 2025-11-19
+ * Updated: 2025-11-20
  *
  * This file contains interfaces that extend the shared-types with UI-specific fields.
  *
@@ -48,7 +48,7 @@ export type UIReminder = Reminder & {
   extension: Record<string, string | number | null>;  // Essentially extension is a dictionary-like object with keys (ex. field names) and values  
   // useful for adding on custom event type fields/extensions that we may not know the types to yet
   // Reminder recurrence fields to fill out UI form
-  recurrence?: recurrenceReminder | null;
+  recurrence?: recurrenceReminder | null | undefined;
   // Used to determine which series table the recurring reminders itemID is from
   originalRecurrenceType?: string | null;
   isRecurring: boolean;
@@ -85,7 +85,7 @@ export type weeklyReminder = {
   eventDurationMin: number;
   notifOffsetTimeMin: number | null;
   everyNWeeks: number;
-  daysOfWeek: string;
+  daysOfWeek: number[];
   seriesEndDate: string;
 };
 

--- a/client/src/types/ui-types.ts
+++ b/client/src/types/ui-types.ts
@@ -2,7 +2,7 @@
 /*
  * Authors: Rachel Patella
  * Created: 2025-10-21
- * Updated: 2025-11-20
+ * Updated: 2025-11-21
  *
  * This file contains interfaces that extend the shared-types with UI-specific fields.
  *
@@ -94,7 +94,7 @@ export type monthlyReminder = {
   eventDurationMin: number;
   notifOffsetTimeMin: number | null;
   lastDayOfMonth: boolean;
-  daysOfMonth: string;
+  daysOfMonth: number[];
   seriesEndDate: string;
 };
 

--- a/client/src/utils/local-db.ts
+++ b/client/src/utils/local-db.ts
@@ -128,6 +128,8 @@ export async function createDailyReminder(
     newDailyRem.extensions = extensions;
   }
   await window.sqliteAPI.createDailyReminder(newDailyRem);
+  // Return timestamp ID of recurring reminder to use in frontend
+  return timeMs; 
 }
 
 export async function createWeeklyReminder(
@@ -164,6 +166,8 @@ export async function createWeeklyReminder(
     newWeeklyRem.extensions = extensions;
   }
   await window.sqliteAPI.createWeeklyReminder(newWeeklyRem);
+  // Return timestamp ID of recurring reminder to use in frontend
+  return timeMs; 
 }
 
 export async function createMonthlyReminder(
@@ -200,6 +204,8 @@ export async function createMonthlyReminder(
     newMonthlyRem.extensions = extensions;
   }
   await window.sqliteAPI.createMonthlyReminder(newMonthlyRem);
+  // Return timestamp ID of recurring reminder to use in frontend
+  return timeMs; 
 }
 
 export async function createYearlyReminder(
@@ -241,6 +247,8 @@ export async function createYearlyReminder(
     newYearlyRem.extensions = extensions;
   }
   await window.sqliteAPI.createYearlyReminder(newYearlyRem);
+  // Return timestamp ID of recurring reminder to use in frontend
+  return timeMs; 
 }
 
 export async function createOrUpdateOverride(


### PR DESCRIPTION
- User can flag a reminder in the middle list as recurring and pick the recurrence type: daily, weekly, monthly, yearly
- Recurring reminders support event types. timeOfDayMin is treated as departure/check-out time and duration is used to compute arrival/check-in time.
- User can cancel edits to a recurring reminder
- Overrides can be created to change the event start and end time on a generated reminder
- Normal reminders, notes, or folder drafts can be created in the middle list from the file explorer add button menu
- Generated reminders only display in middle list and on calendar and have a button to see its series 
- Recurring reminders only display in file explorer and temporarily in middle list when viewing series
- Calendar now displays reminder events as colored dots with a tooltip containing the reminder title
- Multi-day reminders display calendar events for every day in the range of the start and end day
- Fixed various UI bugs including folder nesting